### PR TITLE
[TP-33] 여행 공유 게시글 조회 기능 (최신순, 10개씩) 추가

### DIFF
--- a/src/main/java/com/cocodan/triplan/TriplanApplication.java
+++ b/src/main/java/com/cocodan/triplan/TriplanApplication.java
@@ -5,7 +5,6 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
-@EnableJpaAuditing
 public class TriplanApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/cocodan/triplan/TriplanApplication.java
+++ b/src/main/java/com/cocodan/triplan/TriplanApplication.java
@@ -2,8 +2,10 @@ package com.cocodan.triplan;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class TriplanApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/cocodan/triplan/common/BaseEntity.java
+++ b/src/main/java/com/cocodan/triplan/common/BaseEntity.java
@@ -14,14 +14,14 @@ import java.time.LocalDateTime;
 
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
-public abstract class BaseEntity<U> {
+public abstract class BaseEntity {
     @CreatedBy
     @Column(name = "created_by")
-    private U createdBy;
+    private Long createdBy;
 
     @LastModifiedBy
     @Column(name = "last_modified_by")
-    private U lastModifiedBy;
+    private Long lastModifiedBy;
 
     @CreatedDate
     @Column(name = "created_date")
@@ -34,15 +34,15 @@ public abstract class BaseEntity<U> {
     protected BaseEntity() {
     }
 
-    public void updateLastModifiedMember(U lastModifiedBy) {
+    public void updateLastModifiedMember(Long lastModifiedBy) {
         this.lastModifiedBy = lastModifiedBy;
     }
 
-    public U getCreatedBy() {
+    public Long getCreatedBy() {
         return createdBy;
     }
 
-    public U getLastModifiedBy() {
+    public Long getLastModifiedBy() {
         return lastModifiedBy;
     }
 

--- a/src/main/java/com/cocodan/triplan/member/domain/Member.java
+++ b/src/main/java/com/cocodan/triplan/member/domain/Member.java
@@ -11,7 +11,7 @@ import java.time.LocalDateTime;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Member extends BaseEntity<Long> {
+public class Member extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
     @Column(name = "id", unique = true, nullable = false)

--- a/src/main/java/com/cocodan/triplan/member/repository/MemberRepository.java
+++ b/src/main/java/com/cocodan/triplan/member/repository/MemberRepository.java
@@ -1,0 +1,7 @@
+package com.cocodan.triplan.member.repository;
+
+import com.cocodan.triplan.member.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+}

--- a/src/main/java/com/cocodan/triplan/member/service/MemberService.java
+++ b/src/main/java/com/cocodan/triplan/member/service/MemberService.java
@@ -1,0 +1,20 @@
+package com.cocodan.triplan.member.service;
+
+import com.cocodan.triplan.member.domain.Member;
+import com.cocodan.triplan.member.repository.MemberRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    public MemberService(MemberRepository memberRepository) {
+        this.memberRepository = memberRepository;
+    }
+
+    public Member findById(Long id) {
+        return memberRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("There is no such member with ID: " + id));
+    }
+}

--- a/src/main/java/com/cocodan/triplan/post/schedule/controller/SchedulePostController.java
+++ b/src/main/java/com/cocodan/triplan/post/schedule/controller/SchedulePostController.java
@@ -1,0 +1,35 @@
+package com.cocodan.triplan.post.schedule.controller;
+
+import com.cocodan.triplan.post.schedule.dto.SchedulePostResponse;
+import com.cocodan.triplan.post.schedule.service.SchedulePostService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+import static com.cocodan.triplan.post.schedule.controller.SchedulePostController.schedulePostBaseUri;
+
+@RequestMapping(schedulePostBaseUri)
+@RestController
+public class SchedulePostController {
+
+    public static final String schedulePostBaseUri = "/posts";
+
+    private final SchedulePostService schedulePostService;
+
+    public SchedulePostController(SchedulePostService schedulePostService) {
+        this.schedulePostService = schedulePostService;
+    }
+
+    @GetMapping("/schedules")
+    public List<SchedulePostResponse> scheduleList(@RequestParam(defaultValue = "0") Integer pageIndex) {
+        // 1. 단순 전체조회로 시작 (최신순)
+        List<SchedulePostResponse> posts = schedulePostService.getRecentSchedulePostList(pageIndex);
+        return posts;
+
+        // 2. 검색 조건 추가
+        // 3. 검색 효율성 개선
+    }
+}

--- a/src/main/java/com/cocodan/triplan/post/schedule/domain/Like.java
+++ b/src/main/java/com/cocodan/triplan/post/schedule/domain/Like.java
@@ -14,7 +14,8 @@ import javax.persistence.Table;
 @Entity
 @Table(name = "schedule_post_like")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Like extends BaseEntity<Long> {
+// TODO: 2021.12.07 Teru - 더 직관적인 네이밍 고민
+public class Like extends BaseEntity {
 
     @Id
     @Column(name = "id", nullable = false)

--- a/src/main/java/com/cocodan/triplan/post/schedule/domain/Like.java
+++ b/src/main/java/com/cocodan/triplan/post/schedule/domain/Like.java
@@ -1,5 +1,6 @@
 package com.cocodan.triplan.post.schedule.domain;
 
+import com.cocodan.triplan.common.BaseEntity;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
@@ -13,7 +14,7 @@ import javax.persistence.Table;
 @Entity
 @Table(name = "schedule_post_like")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Like {
+public class Like extends BaseEntity<Long> {
 
     @Id
     @Column(name = "id", nullable = false)

--- a/src/main/java/com/cocodan/triplan/post/schedule/domain/Like.java
+++ b/src/main/java/com/cocodan/triplan/post/schedule/domain/Like.java
@@ -6,6 +6,8 @@ import lombok.NoArgsConstructor;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
@@ -19,6 +21,7 @@ public class Like extends BaseEntity {
 
     @Id
     @Column(name = "id", nullable = false)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Column(name = "member_id", nullable = false)

--- a/src/main/java/com/cocodan/triplan/post/schedule/domain/SchedulePost.java
+++ b/src/main/java/com/cocodan/triplan/post/schedule/domain/SchedulePost.java
@@ -1,12 +1,15 @@
 package com.cocodan.triplan.post.schedule.domain;
 
 import com.cocodan.triplan.common.BaseEntity;
+import com.cocodan.triplan.spot.domain.vo.City;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -39,14 +42,19 @@ public class SchedulePost extends BaseEntity {
     @Column(name = "liked", nullable = false)
     private Long liked;
 
+    @Column(name = "city", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private City city;
+
     @Builder
-    public SchedulePost(Long memberId, Long scheduleId, String title, String content, Long views, Long liked) {
+    public SchedulePost(Long memberId, Long scheduleId, String title, String content, Long views, Long liked, City city) {
         this.memberId = memberId;
         this.scheduleId = scheduleId;
         this.title = title;
         this.content = content;
         this.views = views;
         this.liked = liked;
+        this.city = city;
     }
 
     public Long getId() {
@@ -75,5 +83,9 @@ public class SchedulePost extends BaseEntity {
 
     public Long getLiked() {
         return liked;
+    }
+
+    public City getCity() {
+        return city;
     }
 }

--- a/src/main/java/com/cocodan/triplan/post/schedule/domain/SchedulePost.java
+++ b/src/main/java/com/cocodan/triplan/post/schedule/domain/SchedulePost.java
@@ -1,6 +1,6 @@
 package com.cocodan.triplan.post.schedule.domain;
 
-import com.cocodan.triplan.schedule.domain.Schedule;
+import com.cocodan.triplan.common.BaseEntity;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
@@ -10,14 +10,12 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 
 @Entity
 @Table(name = "schedule_posts")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class SchedulePost {
+public class SchedulePost extends BaseEntity {
 
     @Id
     @Column(name = "id", nullable = false)

--- a/src/main/java/com/cocodan/triplan/post/schedule/domain/SchedulePostComment.java
+++ b/src/main/java/com/cocodan/triplan/post/schedule/domain/SchedulePostComment.java
@@ -1,5 +1,6 @@
 package com.cocodan.triplan.post.schedule.domain;
 
+import com.cocodan.triplan.common.BaseEntity;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
@@ -14,7 +15,7 @@ import javax.persistence.Table;
 @Entity
 @Table(name = "schedule_post_comments")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class SchedulePostComment {
+public class SchedulePostComment extends BaseEntity {
 
     @Id
     @Column(name = "id", nullable = false)

--- a/src/main/java/com/cocodan/triplan/post/schedule/dto/SchedulePostResponse.java
+++ b/src/main/java/com/cocodan/triplan/post/schedule/dto/SchedulePostResponse.java
@@ -5,6 +5,7 @@ import com.cocodan.triplan.member.domain.vo.GenderType;
 import com.cocodan.triplan.post.schedule.vo.Ages;
 import com.cocodan.triplan.schedule.domain.Schedule;
 import com.cocodan.triplan.schedule.domain.vo.Tag;
+import com.cocodan.triplan.spot.domain.vo.City;
 import lombok.Builder;
 
 import java.time.LocalDate;
@@ -22,8 +23,7 @@ public class SchedulePostResponse {
 
     public GenderType genderType;
 
-    // TODO: 2021.12.06 Teru - 도시 엔티티 구현되면 수정
-    public String city;
+    public City city;
 
     // TODO: 현재 테마가 Tag로 잘못 올라가 있음. Tag 명칭 수정되면 같이 수정
     public List<Tag> themes;
@@ -35,7 +35,7 @@ public class SchedulePostResponse {
     @Builder
     private SchedulePostResponse(
             String profileImageUrl, String nickname, String title,
-            Ages ages, GenderType genderType, String city,
+            Ages ages, GenderType genderType, City city,
             List<Tag> themes, LocalDate startDate, LocalDate endDate)
     {
         this.profileImageUrl = profileImageUrl;
@@ -49,8 +49,8 @@ public class SchedulePostResponse {
         this.endDate = endDate;
     }
 
-    // TODO: 2021.12.06 Teru - 도시 엔티니 구현되면 수정, Tag 명칭 수정되면 수정
-    public static SchedulePostResponse from(Member member, Schedule schedule, String city, List<Tag> themes, String title) {
+    // TODO: 2021.12.06 Teru - Tag 명칭 수정되면 수정
+    public static SchedulePostResponse from(Member member, Schedule schedule, City city, List<Tag> themes, String title) {
         return SchedulePostResponse.builder()
                 .profileImageUrl(member.getProfileImage())
                 .nickname(member.getNickname())

--- a/src/main/java/com/cocodan/triplan/post/schedule/dto/SchedulePostResponse.java
+++ b/src/main/java/com/cocodan/triplan/post/schedule/dto/SchedulePostResponse.java
@@ -4,7 +4,7 @@ import com.cocodan.triplan.member.domain.Member;
 import com.cocodan.triplan.member.domain.vo.GenderType;
 import com.cocodan.triplan.post.schedule.vo.Ages;
 import com.cocodan.triplan.schedule.domain.Schedule;
-import com.cocodan.triplan.schedule.domain.vo.Tag;
+import com.cocodan.triplan.schedule.domain.vo.Thema;
 import com.cocodan.triplan.spot.domain.vo.City;
 import lombok.Builder;
 
@@ -13,30 +13,30 @@ import java.util.List;
 
 public class SchedulePostResponse {
 
-    public String profileImageUrl;
+    private String profileImageUrl;
 
-    public String nickname;
+    private String nickname;
 
-    public String title;
+    private String title;
 
-    public Ages ages;
+    private Ages ages;
 
-    public GenderType genderType;
+    private GenderType genderType;
 
-    public City city;
+    private City city;
 
     // TODO: 현재 테마가 Tag로 잘못 올라가 있음. Tag 명칭 수정되면 같이 수정
-    public List<Tag> themes;
+    private List<Thema> themes;
 
-    public LocalDate startDate;
+    private LocalDate startDate;
 
-    public LocalDate endDate;
+    private LocalDate endDate;
 
     @Builder
     private SchedulePostResponse(
             String profileImageUrl, String nickname, String title,
             Ages ages, GenderType genderType, City city,
-            List<Tag> themes, LocalDate startDate, LocalDate endDate)
+            List<Thema> themes, LocalDate startDate, LocalDate endDate)
     {
         this.profileImageUrl = profileImageUrl;
         this.nickname = nickname;
@@ -50,7 +50,7 @@ public class SchedulePostResponse {
     }
 
     // TODO: 2021.12.06 Teru - Tag 명칭 수정되면 수정
-    public static SchedulePostResponse from(Member member, Schedule schedule, City city, List<Tag> themes, String title) {
+    public static SchedulePostResponse from(Member member, Schedule schedule, City city, List<Thema> themes, String title) {
         return SchedulePostResponse.builder()
                 .profileImageUrl(member.getProfileImage())
                 .nickname(member.getNickname())
@@ -62,5 +62,77 @@ public class SchedulePostResponse {
                 .startDate(schedule.getStartDate())
                 .endDate(schedule.getEndDate())
                 .build();
+    }
+
+    public String getProfileImageUrl() {
+        return profileImageUrl;
+    }
+
+    public void setProfileImageUrl(String profileImageUrl) {
+        this.profileImageUrl = profileImageUrl;
+    }
+
+    public String getNickname() {
+        return nickname;
+    }
+
+    public void setNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public Ages getAges() {
+        return ages;
+    }
+
+    public void setAges(Ages ages) {
+        this.ages = ages;
+    }
+
+    public GenderType getGenderType() {
+        return genderType;
+    }
+
+    public void setGenderType(GenderType genderType) {
+        this.genderType = genderType;
+    }
+
+    public City getCity() {
+        return city;
+    }
+
+    public void setCity(City city) {
+        this.city = city;
+    }
+
+    public List<Thema> getThemes() {
+        return themes;
+    }
+
+    public void setThemes(List<Thema> themes) {
+        this.themes = themes;
+    }
+
+    public LocalDate getStartDate() {
+        return startDate;
+    }
+
+    public void setStartDate(LocalDate startDate) {
+        this.startDate = startDate;
+    }
+
+    public LocalDate getEndDate() {
+        return endDate;
+    }
+
+    public void setEndDate(LocalDate endDate) {
+        this.endDate = endDate;
     }
 }

--- a/src/main/java/com/cocodan/triplan/post/schedule/dto/SchedulePostResponse.java
+++ b/src/main/java/com/cocodan/triplan/post/schedule/dto/SchedulePostResponse.java
@@ -1,0 +1,66 @@
+package com.cocodan.triplan.post.schedule.dto;
+
+import com.cocodan.triplan.member.domain.Member;
+import com.cocodan.triplan.member.domain.vo.GenderType;
+import com.cocodan.triplan.post.schedule.vo.Ages;
+import com.cocodan.triplan.schedule.domain.Schedule;
+import com.cocodan.triplan.schedule.domain.vo.Tag;
+import lombok.Builder;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public class SchedulePostResponse {
+
+    public String profileImageUrl;
+
+    public String nickname;
+
+    public String title;
+
+    public Ages ages;
+
+    public GenderType genderType;
+
+    // TODO: 2021.12.06 Teru - 도시 엔티티 구현되면 수정
+    public String city;
+
+    // TODO: 현재 테마가 Tag로 잘못 올라가 있음. Tag 명칭 수정되면 같이 수정
+    public List<Tag> themes;
+
+    public LocalDate startDate;
+
+    public LocalDate endDate;
+
+    @Builder
+    private SchedulePostResponse(
+            String profileImageUrl, String nickname, String title,
+            Ages ages, GenderType genderType, String city,
+            List<Tag> themes, LocalDate startDate, LocalDate endDate)
+    {
+        this.profileImageUrl = profileImageUrl;
+        this.nickname = nickname;
+        this.title = title;
+        this.ages = ages;
+        this.genderType = genderType;
+        this.city = city;
+        this.themes = themes;
+        this.startDate = startDate;
+        this.endDate = endDate;
+    }
+
+    // TODO: 2021.12.06 Teru - 도시 엔티니 구현되면 수정, Tag 명칭 수정되면 수정
+    public static SchedulePostResponse from(Member member, Schedule schedule, String city, List<Tag> themes, String title) {
+        return SchedulePostResponse.builder()
+                .profileImageUrl(member.getProfileImage())
+                .nickname(member.getNickname())
+                .title(title)
+                .ages(Ages.from(member.getBirth()))
+                .genderType(member.getGender())
+                .city(city)
+                .themes(themes)
+                .startDate(schedule.getStartDate())
+                .endDate(schedule.getEndDate())
+                .build();
+    }
+}

--- a/src/main/java/com/cocodan/triplan/post/schedule/repository/SchedulePostRepository.java
+++ b/src/main/java/com/cocodan/triplan/post/schedule/repository/SchedulePostRepository.java
@@ -1,0 +1,14 @@
+package com.cocodan.triplan.post.schedule.repository;
+
+import com.cocodan.triplan.post.schedule.domain.SchedulePost;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+
+public interface SchedulePostRepository extends JpaRepository<SchedulePost, Long> {
+
+    // 최신순으로 page index부터 10개 게시글 불러오기
+    List<SchedulePost> findAllByOrderByCreatedDateDesc(Pageable pageable);
+}

--- a/src/main/java/com/cocodan/triplan/post/schedule/service/SchedulePostService.java
+++ b/src/main/java/com/cocodan/triplan/post/schedule/service/SchedulePostService.java
@@ -1,0 +1,52 @@
+package com.cocodan.triplan.post.schedule.service;
+
+import com.cocodan.triplan.member.domain.Member;
+import com.cocodan.triplan.post.schedule.domain.SchedulePost;
+import com.cocodan.triplan.post.schedule.dto.SchedulePostResponse;
+import com.cocodan.triplan.post.schedule.repository.SchedulePostRepository;
+import com.cocodan.triplan.member.service.MemberService;
+import com.cocodan.triplan.schedule.domain.Schedule;
+import com.cocodan.triplan.schedule.domain.ScheduleTag;
+import com.cocodan.triplan.schedule.domain.vo.Tag;
+import com.cocodan.triplan.schedule.service.ScheduleService;
+import com.cocodan.triplan.spot.domain.vo.City;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class SchedulePostService {
+
+    private final int PAGE_SIZE = 10;
+
+    private final MemberService memberService;
+
+    private final ScheduleService scheduleService;
+
+    private final SchedulePostRepository schedulePostRepository;
+
+    public SchedulePostService(MemberService memberService, ScheduleService scheduleService, SchedulePostRepository schedulePostRepository) {
+        this.memberService = memberService;
+        this.scheduleService = scheduleService;
+        this.schedulePostRepository = schedulePostRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public List<SchedulePostResponse> getRecentSchedulePostList(Integer pageIndex) {
+        List<SchedulePost> schedulePosts =
+                schedulePostRepository.findAllByOrderByCreatedDateDesc(PageRequest.of(pageIndex, PAGE_SIZE));
+        return schedulePosts.stream().map(schedulePost -> {
+            Member member = memberService.findById(schedulePost.getMemberId());
+            Schedule schedule = scheduleService.findById(schedulePost.getScheduleId());
+            City city = schedulePost.getCity();
+            List<Tag> themes = schedule.getScheduleTags().stream()
+                    .map(ScheduleTag::getTag).collect(Collectors.toList());
+            String title = schedulePost.getTitle();
+
+            return SchedulePostResponse.from(member, schedule, city, themes, title);
+        }).collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/cocodan/triplan/post/schedule/service/SchedulePostService.java
+++ b/src/main/java/com/cocodan/triplan/post/schedule/service/SchedulePostService.java
@@ -7,7 +7,9 @@ import com.cocodan.triplan.post.schedule.repository.SchedulePostRepository;
 import com.cocodan.triplan.member.service.MemberService;
 import com.cocodan.triplan.schedule.domain.Schedule;
 import com.cocodan.triplan.schedule.domain.ScheduleTag;
+import com.cocodan.triplan.schedule.domain.ScheduleThema;
 import com.cocodan.triplan.schedule.domain.vo.Tag;
+import com.cocodan.triplan.schedule.domain.vo.Thema;
 import com.cocodan.triplan.schedule.service.ScheduleService;
 import com.cocodan.triplan.spot.domain.vo.City;
 import org.springframework.data.domain.PageRequest;
@@ -42,8 +44,8 @@ public class SchedulePostService {
             Member member = memberService.findById(schedulePost.getMemberId());
             Schedule schedule = scheduleService.findById(schedulePost.getScheduleId());
             City city = schedulePost.getCity();
-            List<Tag> themes = schedule.getScheduleTags().stream()
-                    .map(ScheduleTag::getTag).collect(Collectors.toList());
+            List<Thema> themes = schedule.getScheduleThemas().stream()
+                    .map(ScheduleThema::getThema).collect(Collectors.toList());
             String title = schedulePost.getTitle();
 
             return SchedulePostResponse.from(member, schedule, city, themes, title);

--- a/src/main/java/com/cocodan/triplan/post/schedule/vo/Age.java
+++ b/src/main/java/com/cocodan/triplan/post/schedule/vo/Age.java
@@ -1,0 +1,49 @@
+package com.cocodan.triplan.post.schedule.vo;
+
+import java.time.LocalDate;
+
+public enum Ages {
+    TEENS("10대"),
+    TWENTIES("20대"),
+    THIRTIES("30대"),
+    FORTIES("40대"),
+    FIFTIES("50대"),
+    SIXTIES("60대"),
+    ELDER("70대 이상");
+
+    private final String ages;
+
+    Ages(String ages) {
+        this.ages = age;
+    }
+
+    public static Ages from(String birth) { // Suppose : format of birth => YYYYMMDD
+        int thisYear = LocalDate.now().getYear();
+        int birthYear = Integer.parseInt(birth.substring(0, 4));
+        int age = thisYear - birthYear + 1; // 잘못된 birth는 없다고 가정
+
+        switch (age / 10) {
+            case 0:
+                // TODO: 2021.12.06 Teru - 별도 Exception 정의하기
+                throw new RuntimeException("어린이는 이용할 수 없는 서비스입니다.");
+            case 1:
+                return Ages.TEENS;
+            case 2:
+                return Ages.TWENTIES;
+            case 3:
+                return Ages.THIRTIES;
+            case 4:
+                return Ages.FIFTIES;
+            case 5:
+                return Ages.FIFTIES;
+            case 6:
+                return Ages.SIXTIES;
+            default:
+                return Ages.ELDER;
+        }
+    }
+
+    public String getAges() {
+        return ages;
+    }
+}

--- a/src/main/java/com/cocodan/triplan/post/schedule/vo/Ages.java
+++ b/src/main/java/com/cocodan/triplan/post/schedule/vo/Ages.java
@@ -14,7 +14,7 @@ public enum Ages {
     private final String ages;
 
     Ages(String ages) {
-        this.ages = age;
+        this.ages = ages;
     }
 
     public static Ages from(String birth) { // Suppose : format of birth => YYYYMMDD

--- a/src/main/java/com/cocodan/triplan/schedule/domain/ScheduleThema.java
+++ b/src/main/java/com/cocodan/triplan/schedule/domain/ScheduleThema.java
@@ -38,4 +38,8 @@ public class ScheduleThema {
     public Thema getThema() {
         return thema;
     }
+
+    public Schedule getSchedule() {
+        return schedule;
+    }
 }

--- a/src/main/java/com/cocodan/triplan/schedule/service/ScheduleService.java
+++ b/src/main/java/com/cocodan/triplan/schedule/service/ScheduleService.java
@@ -128,5 +128,10 @@ public class ScheduleService {
                 .voting(voting)
                 .build();
     }
-
+    
+    // TODO: 2021.12.08 Teru - Remove after checking its usage and use Henry's code if necessary.
+    public Schedule findById(Long id) {
+        return scheduleRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("There is no such member with ID : " + id));
+    }
 }

--- a/src/main/java/com/cocodan/triplan/spot/domain/vo/City.java
+++ b/src/main/java/com/cocodan/triplan/spot/domain/vo/City.java
@@ -1,0 +1,18 @@
+package com.cocodan.triplan.spot.domain.vo;
+
+public enum City {
+    SEOUL("서울"),
+    BUSAN("부산"),
+    INCHEON("인천"),
+    JEJU("제주");
+
+    private final String city;
+
+    City(String city) {
+        this.city = city;
+    }
+
+    public String getCity() {
+        return city;
+    }
+}


### PR DESCRIPTION
* 검색 조건, 정렬 조건은 다른 티켓으로 분리했습니다. 그래서 일단 가장 기본적인 기능만 붙여두었습니다.
* 하나의 완성된 단위로 PR 하고 싶었는데, 다른 도메인 의존성이 커서 불가피하게 이렇게 하게 되었습니다.