### PR TITLE
[TP-34] 공유된 여행 게시글 상세 조회 기능 구현

### DIFF
--- a/src/main/java/com/cocodan/triplan/converter/ScheduleConverter.java
+++ b/src/main/java/com/cocodan/triplan/converter/ScheduleConverter.java
@@ -1,8 +1,9 @@
 package com.cocodan.triplan.converter;
 
-import com.cocodan.triplan.member.domain.Member;
-import com.cocodan.triplan.schedule.domain.*;
-import com.cocodan.triplan.schedule.domain.vo.Thema;
+import com.cocodan.triplan.schedule.domain.DailyScheduleSpot;
+import com.cocodan.triplan.schedule.domain.Schedule;
+import com.cocodan.triplan.schedule.domain.ScheduleThema;
+import com.cocodan.triplan.schedule.domain.vo.Theme;
 import com.cocodan.triplan.schedule.dto.request.DailyScheduleSpotCreationRequest;
 import com.cocodan.triplan.schedule.dto.request.ScheduleCreationRequest;
 import com.cocodan.triplan.schedule.dto.request.ScheduleModificationRequest;
@@ -33,7 +34,7 @@ public class ScheduleConverter {
 
         scheduleCreationRequest.getThemas()
                 .stream()
-                .map(s -> Thema.valueOf(s.toUpperCase()))
+                .map(s -> Theme.valueOf(s.toUpperCase()))
                 .map(thema -> new ScheduleThema(schedule, thema))
                 .collect(Collectors.toList());
 
@@ -64,7 +65,7 @@ public class ScheduleConverter {
                 .build();
     }
 
-    private List<Thema> getThema(Schedule schedule) {
+    private List<Theme> getThema(Schedule schedule) {
         return schedule.getScheduleThemas().stream()
                 .map(ScheduleThema::getThema)
                 .collect(Collectors.toList());
@@ -76,7 +77,7 @@ public class ScheduleConverter {
                 .startDate(schedule.getStartDate())
                 .endDate(schedule.getEndDate())
                 .title(schedule.getTitle())
-                .themas(getThema(schedule))
+                .thema(getThema(schedule))
                 .spotSimpleList(getSpotSimple(spotList))
                 .memberImageUrls(imageUrls)
                 .build();

--- a/src/main/java/com/cocodan/triplan/converter/ScheduleConverter.java
+++ b/src/main/java/com/cocodan/triplan/converter/ScheduleConverter.java
@@ -1,8 +1,12 @@
 package com.cocodan.triplan.converter;
 
+import com.cocodan.triplan.member.domain.Member;
 import com.cocodan.triplan.schedule.domain.DailyScheduleSpot;
+import com.cocodan.triplan.schedule.domain.Memo;
 import com.cocodan.triplan.schedule.domain.Schedule;
 import com.cocodan.triplan.schedule.domain.ScheduleThema;
+import com.cocodan.triplan.schedule.domain.Voting;
+import com.cocodan.triplan.schedule.domain.VotingContent;
 import com.cocodan.triplan.schedule.domain.vo.Theme;
 import com.cocodan.triplan.schedule.dto.request.DailyScheduleSpotCreationRequest;
 import com.cocodan.triplan.schedule.dto.request.ScheduleCreationRequest;

--- a/src/main/java/com/cocodan/triplan/post/schedule/controller/SchedulePostController.java
+++ b/src/main/java/com/cocodan/triplan/post/schedule/controller/SchedulePostController.java
@@ -6,7 +6,7 @@ import com.cocodan.triplan.post.schedule.dto.response.SchedulePostCreateResponse
 import com.cocodan.triplan.post.schedule.dto.response.SchedulePostResponse;
 import com.cocodan.triplan.post.schedule.service.SchedulePostService;
 import com.cocodan.triplan.post.schedule.vo.SchedulePostSortingRule;
-import com.cocodan.triplan.schedule.domain.vo.Thema;
+import com.cocodan.triplan.schedule.domain.vo.Theme;
 import com.cocodan.triplan.spot.domain.vo.City;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -43,7 +43,7 @@ public class SchedulePostController {
             @RequestParam(defaultValue = "최신순") String sorting
     ) {
         City city = City.of(searchingCity);
-        Thema theme = Thema.valueOf(searchingTheme);
+        Theme theme = Theme.valueOf(searchingTheme);
         SchedulePostSortingRule sortRule = SchedulePostSortingRule.of(sorting);
 
         List<SchedulePostResponse> schedulePostList

--- a/src/main/java/com/cocodan/triplan/post/schedule/controller/SchedulePostController.java
+++ b/src/main/java/com/cocodan/triplan/post/schedule/controller/SchedulePostController.java
@@ -3,6 +3,7 @@ package com.cocodan.triplan.post.schedule.controller;
 import com.cocodan.triplan.member.domain.Member;
 import com.cocodan.triplan.post.schedule.dto.request.SchedulePostCreateRequest;
 import com.cocodan.triplan.post.schedule.dto.response.SchedulePostCreateResponse;
+import com.cocodan.triplan.post.schedule.dto.response.SchedulePostDetailResponse;
 import com.cocodan.triplan.post.schedule.dto.response.SchedulePostResponse;
 import com.cocodan.triplan.post.schedule.service.SchedulePostService;
 import com.cocodan.triplan.post.schedule.vo.SchedulePostSortingRule;
@@ -12,6 +13,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -35,7 +37,7 @@ public class SchedulePostController {
     }
 
     @GetMapping("/schedules")
-    public ResponseEntity<List<SchedulePostResponse>> scheduleList(
+    public ResponseEntity<List<SchedulePostResponse>> schedulePostList(
             @RequestParam(defaultValue = "0") Integer pageIndex,
             @RequestParam(defaultValue = "") String search,
             @RequestParam(defaultValue = "전체") String searchingCity,
@@ -47,9 +49,9 @@ public class SchedulePostController {
         SchedulePostSortingRule sortRule = SchedulePostSortingRule.of(sorting);
 
         List<SchedulePostResponse> schedulePostList
-                = schedulePostService.getSchedulePostList(search, city, theme, sortRule, pageIndex);
+                = schedulePostService.getSchedulePosts(search, city, theme, sortRule, pageIndex);
 
-        return new ResponseEntity<>(schedulePostList, HttpStatus.OK);
+        return ResponseEntity.ok(schedulePostList);
         // TODO: 검색 효율성 개선
     }
 
@@ -57,7 +59,12 @@ public class SchedulePostController {
     public ResponseEntity<SchedulePostCreateResponse> createSchedulePost(@RequestBody SchedulePostCreateRequest request) {
         Member member = (Member) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
         Long postId = schedulePostService.createSchedulePost(member.getId(), request);
-        return new ResponseEntity<>(SchedulePostCreateResponse.from(postId), HttpStatus.OK);
+        return ResponseEntity.ok(SchedulePostCreateResponse.from(postId));
     }
 
+    @GetMapping("/{postId}/schedules")
+    public ResponseEntity<SchedulePostDetailResponse> detailSchedulePost(@PathVariable Long postId) {
+        SchedulePostDetailResponse schedulePostDetail = schedulePostService.getSchedulePostDetail(postId);
+        return ResponseEntity.ok(schedulePostDetail);
+    }
 }

--- a/src/main/java/com/cocodan/triplan/post/schedule/controller/SchedulePostController.java
+++ b/src/main/java/com/cocodan/triplan/post/schedule/controller/SchedulePostController.java
@@ -62,9 +62,9 @@ public class SchedulePostController {
         return ResponseEntity.ok(SchedulePostCreateResponse.from(postId));
     }
 
-    @GetMapping("/{postId}/schedules")
-    public ResponseEntity<SchedulePostDetailResponse> detailSchedulePost(@PathVariable Long postId) {
-        SchedulePostDetailResponse schedulePostDetail = schedulePostService.getSchedulePostDetail(postId);
+    @GetMapping("/schedules/{schedulePostId}")
+    public ResponseEntity<SchedulePostDetailResponse> detailSchedulePost(@PathVariable Long schedulePostId) {
+        SchedulePostDetailResponse schedulePostDetail = schedulePostService.getSchedulePostDetail(schedulePostId);
         return ResponseEntity.ok(schedulePostDetail);
     }
 }

--- a/src/main/java/com/cocodan/triplan/post/schedule/domain/SchedulePost.java
+++ b/src/main/java/com/cocodan/triplan/post/schedule/domain/SchedulePost.java
@@ -1,6 +1,7 @@
 package com.cocodan.triplan.post.schedule.domain;
 
 import com.cocodan.triplan.common.BaseEntity;
+import com.cocodan.triplan.member.domain.Member;
 import com.cocodan.triplan.schedule.domain.Schedule;
 import com.cocodan.triplan.spot.domain.vo.City;
 import lombok.AccessLevel;
@@ -29,8 +30,9 @@ public class SchedulePost extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "member_id", nullable = false)
-    private Long memberId;
+    @ManyToOne
+    @JoinColumn(name = "member", referencedColumnName = "id")
+    private Member member;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "schedule", referencedColumnName = "id")
@@ -39,7 +41,7 @@ public class SchedulePost extends BaseEntity {
     @Column(name = "title", nullable = false)
     private String title;
 
-    @Column(name = "content", nullable = false)
+    @Column(name = "content", nullable = false, columnDefinition = "text")
     private String content;
 
     @Column(name = "views", nullable = false)
@@ -53,8 +55,8 @@ public class SchedulePost extends BaseEntity {
     private City city;
 
     @Builder
-    public SchedulePost(Long memberId, Schedule schedule, String title, String content, Long views, Long liked, City city) {
-        this.memberId = memberId;
+    public SchedulePost(Member member, Schedule schedule, String title, String content, Long views, Long liked, City city) {
+        this.member = member;
         this.schedule = schedule;
         this.title = title;
         this.content = content;
@@ -67,8 +69,8 @@ public class SchedulePost extends BaseEntity {
         return id;
     }
 
-    public Long getMemberId() {
-        return memberId;
+    public Member getMember() {
+        return member;
     }
 
     public Schedule getSchedule() {

--- a/src/main/java/com/cocodan/triplan/post/schedule/domain/SchedulePost.java
+++ b/src/main/java/com/cocodan/triplan/post/schedule/domain/SchedulePost.java
@@ -30,7 +30,7 @@ public class SchedulePost extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member", referencedColumnName = "id")
     private Member member;
 

--- a/src/main/java/com/cocodan/triplan/post/schedule/dto/response/SchedulePostDetailResponse.java
+++ b/src/main/java/com/cocodan/triplan/post/schedule/dto/response/SchedulePostDetailResponse.java
@@ -1,0 +1,81 @@
+package com.cocodan.triplan.post.schedule.dto.response;
+
+import com.cocodan.triplan.member.domain.vo.GenderType;
+import com.cocodan.triplan.post.schedule.domain.SchedulePost;
+import com.cocodan.triplan.post.schedule.vo.Ages;
+import com.cocodan.triplan.schedule.dto.response.DailyScheduleSpotResponse;
+import com.cocodan.triplan.spot.domain.vo.City;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class SchedulePostDetailResponse {
+
+    private String nickname;
+
+    private Ages ages;
+
+    private GenderType gender;
+
+    private City city;
+
+    private LocalDate startDate;
+
+    private LocalDate endDate;
+
+    private String title;
+
+    private String content;
+
+    private List<DailyScheduleSpotResponse> dailyScheduleSpots;
+
+    private LocalDateTime createdAt;
+
+    private Long views;
+
+    private Long liked;
+
+    // TODO: 2021.12.09 Teru - Comment 추가
+
+    public static SchedulePostDetailResponse from(SchedulePost schedulePost) {
+        return SchedulePostDetailResponse.builder()
+                .nickname(schedulePost.getMember().getNickname())
+                .ages(Ages.from(schedulePost.getMember().getBirth()))
+                .gender(schedulePost.getMember().getGender())
+                .city(schedulePost.getCity())
+                .startDate(schedulePost.getSchedule().getStartDate())
+                .endDate(schedulePost.getSchedule().getEndDate())
+                .title(schedulePost.getTitle())
+                .content(schedulePost.getContent())
+                .dailyScheduleSpots(schedulePost.getSchedule().getDailyScheduleSpots().stream()
+                        .map(DailyScheduleSpotResponse::from)
+                        .collect(Collectors.toList())
+                )
+                .createdAt(schedulePost.getCreatedDate())
+                .views(schedulePost.getViews())
+                .liked(schedulePost.getLiked())
+                .build();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        SchedulePostDetailResponse that = (SchedulePostDetailResponse) o;
+        return nickname.equals(that.nickname) && ages == that.ages && gender == that.gender && city == that.city && startDate.equals(that.startDate) && endDate.equals(that.endDate) && title.equals(that.title) && content.equals(that.content) && dailyScheduleSpots.equals(that.dailyScheduleSpots) && createdAt.equals(that.createdAt) && views.equals(that.views) && liked.equals(that.liked);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(nickname, ages, gender, city, startDate, endDate, title, content, dailyScheduleSpots, createdAt, views, liked);
+    }
+}

--- a/src/main/java/com/cocodan/triplan/post/schedule/dto/response/SchedulePostDetailResponse.java
+++ b/src/main/java/com/cocodan/triplan/post/schedule/dto/response/SchedulePostDetailResponse.java
@@ -73,9 +73,4 @@ public class SchedulePostDetailResponse {
         SchedulePostDetailResponse that = (SchedulePostDetailResponse) o;
         return nickname.equals(that.nickname) && ages == that.ages && gender == that.gender && city == that.city && startDate.equals(that.startDate) && endDate.equals(that.endDate) && title.equals(that.title) && content.equals(that.content) && dailyScheduleSpots.equals(that.dailyScheduleSpots) && createdAt.equals(that.createdAt) && views.equals(that.views) && liked.equals(that.liked);
     }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(nickname, ages, gender, city, startDate, endDate, title, content, dailyScheduleSpots, createdAt, views, liked);
-    }
 }

--- a/src/main/java/com/cocodan/triplan/post/schedule/dto/response/SchedulePostResponse.java
+++ b/src/main/java/com/cocodan/triplan/post/schedule/dto/response/SchedulePostResponse.java
@@ -1,17 +1,21 @@
 package com.cocodan.triplan.post.schedule.dto.response;
 
-import com.cocodan.triplan.member.domain.Member;
 import com.cocodan.triplan.member.domain.vo.GenderType;
 import com.cocodan.triplan.member.dto.response.MemberGetOneResponse;
 import com.cocodan.triplan.post.schedule.vo.Ages;
 import com.cocodan.triplan.schedule.domain.Schedule;
-import com.cocodan.triplan.schedule.domain.vo.Thema;
+import com.cocodan.triplan.schedule.domain.vo.Theme;
 import com.cocodan.triplan.spot.domain.vo.City;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 
 import java.time.LocalDate;
 import java.util.List;
 
+@Getter
+@AllArgsConstructor
+@Builder
 public class SchedulePostResponse {
 
     private String profileImageUrl;
@@ -26,31 +30,13 @@ public class SchedulePostResponse {
 
     private City city;
 
-    // TODO: 현재 테마가 Tag로 잘못 올라가 있음. Tag 명칭 수정되면 같이 수정
-    private List<Thema> themes;
+    private List<Theme> thema;
 
     private LocalDate startDate;
 
     private LocalDate endDate;
 
-    @Builder
-    private SchedulePostResponse(
-            String profileImageUrl, String nickname, String title,
-            Ages ages, GenderType genderType, City city,
-            List<Thema> themes, LocalDate startDate, LocalDate endDate)
-    {
-        this.profileImageUrl = profileImageUrl;
-        this.nickname = nickname;
-        this.title = title;
-        this.ages = ages;
-        this.genderType = genderType;
-        this.city = city;
-        this.themes = themes;
-        this.startDate = startDate;
-        this.endDate = endDate;
-    }
-
-    public static SchedulePostResponse from(MemberGetOneResponse member, Schedule schedule, City city, List<Thema> themes, String title) {
+    public static SchedulePostResponse from(MemberGetOneResponse member, Schedule schedule, City city, List<Theme> themes, String title) {
         return SchedulePostResponse.builder()
                 .profileImageUrl(member.getProfileImage())
                 .nickname(member.getNickname())
@@ -58,81 +44,9 @@ public class SchedulePostResponse {
                 .ages(Ages.from(member.getBirth()))
                 .genderType(member.getGender())
                 .city(city)
-                .themes(themes)
+                .thema(themes)
                 .startDate(schedule.getStartDate())
                 .endDate(schedule.getEndDate())
                 .build();
-    }
-
-    public String getProfileImageUrl() {
-        return profileImageUrl;
-    }
-
-    public void setProfileImageUrl(String profileImageUrl) {
-        this.profileImageUrl = profileImageUrl;
-    }
-
-    public String getNickname() {
-        return nickname;
-    }
-
-    public void setNickname(String nickname) {
-        this.nickname = nickname;
-    }
-
-    public String getTitle() {
-        return title;
-    }
-
-    public void setTitle(String title) {
-        this.title = title;
-    }
-
-    public Ages getAges() {
-        return ages;
-    }
-
-    public void setAges(Ages ages) {
-        this.ages = ages;
-    }
-
-    public GenderType getGenderType() {
-        return genderType;
-    }
-
-    public void setGenderType(GenderType genderType) {
-        this.genderType = genderType;
-    }
-
-    public City getCity() {
-        return city;
-    }
-
-    public void setCity(City city) {
-        this.city = city;
-    }
-
-    public List<Thema> getThemes() {
-        return themes;
-    }
-
-    public void setThemes(List<Thema> themes) {
-        this.themes = themes;
-    }
-
-    public LocalDate getStartDate() {
-        return startDate;
-    }
-
-    public void setStartDate(LocalDate startDate) {
-        this.startDate = startDate;
-    }
-
-    public LocalDate getEndDate() {
-        return endDate;
-    }
-
-    public void setEndDate(LocalDate endDate) {
-        this.endDate = endDate;
     }
 }

--- a/src/main/java/com/cocodan/triplan/post/schedule/repository/SchedulePostRepository.java
+++ b/src/main/java/com/cocodan/triplan/post/schedule/repository/SchedulePostRepository.java
@@ -1,14 +1,9 @@
 package com.cocodan.triplan.post.schedule.repository;
 
 import com.cocodan.triplan.post.schedule.domain.SchedulePost;
-import com.cocodan.triplan.post.schedule.vo.SchedulePostSortingRule;
-import com.cocodan.triplan.schedule.domain.Schedule;
-import com.cocodan.triplan.schedule.domain.vo.Thema;
 import com.cocodan.triplan.spot.domain.vo.City;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.util.Streamable;
 
 import java.util.List;
 
@@ -17,7 +12,7 @@ public interface SchedulePostRepository extends JpaRepository<SchedulePost, Long
     // TODO: 2021.12.09 Teru - List가 아니라 Page 형태로 반환하도록 수정하기
     List<SchedulePost> findAllByOrderByCreatedDateDesc(Pageable pageable);
     List<SchedulePost> findAllByOrderByViewsDesc(Pageable pageable);
-    // @Query("select sp from SchedulePost as sp where (sp.title like %:search% or sp.content like %:search%) order by sp.createdDate desc")
+    // @Query("select sp from SchedulePost as sp where (sp.title like %:search% or sp.content like %:search%) and sp.schedule.scheduleThemas. order by sp.createdDate desc")
     List<SchedulePost> findAllByTitleOrContentContainingOrderByCreatedDateDesc(String title, String content, Pageable pageable);
     List<SchedulePost> findAllByTitleOrContentContainingOrderByViewsDesc(String title, String content, Pageable pageable);
     List<SchedulePost> findAllByCityOrderByCreatedDateDesc(City city, Pageable pageable);

--- a/src/main/java/com/cocodan/triplan/post/schedule/service/SchedulePostService.java
+++ b/src/main/java/com/cocodan/triplan/post/schedule/service/SchedulePostService.java
@@ -1,8 +1,11 @@
 package com.cocodan.triplan.post.schedule.service;
 
+import com.cocodan.triplan.member.domain.Member;
 import com.cocodan.triplan.member.dto.response.MemberGetOneResponse;
+import com.cocodan.triplan.member.repository.MemberRepository;
 import com.cocodan.triplan.post.schedule.domain.SchedulePost;
 import com.cocodan.triplan.post.schedule.dto.request.SchedulePostCreateRequest;
+import com.cocodan.triplan.post.schedule.dto.response.SchedulePostDetailResponse;
 import com.cocodan.triplan.post.schedule.dto.response.SchedulePostResponse;
 import com.cocodan.triplan.post.schedule.repository.SchedulePostRepository;
 import com.cocodan.triplan.member.service.MemberService;
@@ -28,15 +31,14 @@ public class SchedulePostService {
 
     private final MemberService memberService;
 
-    private final ScheduleService scheduleService;
-
+    private final MemberRepository memberRepository;
     private final ScheduleRepository scheduleRepository;
 
     private final SchedulePostRepository schedulePostRepository;
 
-    public SchedulePostService(MemberService memberService, ScheduleService scheduleService, ScheduleRepository scheduleRepository, SchedulePostRepository schedulePostRepository) {
+    public SchedulePostService(MemberService memberService, ScheduleService scheduleService, MemberRepository memberRepository, ScheduleRepository scheduleRepository, SchedulePostRepository schedulePostRepository) {
         this.memberService = memberService;
-        this.scheduleService = scheduleService;
+        this.memberRepository = memberRepository;
         this.scheduleRepository = scheduleRepository;
         this.schedulePostRepository = schedulePostRepository;
     }
@@ -49,8 +51,11 @@ public class SchedulePostService {
     }
 
     public Long createSchedulePost(Long memberId, SchedulePostCreateRequest request) {
+        Member member = memberRepository.findById(memberId).orElseThrow(
+                () -> new RuntimeException("Invalid User Detected")
+        );
         SchedulePost post = SchedulePost.builder()
-                .memberId(memberId)
+                .member(member)
                 .schedule(scheduleRepository.findById(request.getScheduleId()).orElseThrow(
                         () -> new RuntimeException("There is no such schedule (ID : " + request.getScheduleId() + ")")
                 ))
@@ -66,7 +71,7 @@ public class SchedulePostService {
     }
 
     @Transactional(readOnly = true)
-    public List<SchedulePostResponse> getSchedulePostList(
+    public List<SchedulePostResponse> getSchedulePosts(
             String search,
             City city,
             Theme theme,
@@ -135,9 +140,18 @@ public class SchedulePostService {
         return Collections.emptyList();
     }
 
+    @Transactional(readOnly = true)
+    public SchedulePostDetailResponse getSchedulePostDetail(Long postId) {
+        SchedulePost schedulePost = schedulePostRepository.findById(postId).orElseThrow(
+                () -> new RuntimeException("No such post found (ID : " + postId + ")")
+        );
+
+        return SchedulePostDetailResponse.from(schedulePost);
+    }
+
     private List<SchedulePostResponse> convertToSchedulePostResponseList(List<SchedulePost> schedulePosts) {
         return schedulePosts.stream().map(schedulePost -> {
-            MemberGetOneResponse memberResponse = memberService.getOne(schedulePost.getMemberId());
+            MemberGetOneResponse memberResponse = memberService.getOne(schedulePost.getMember().getId());
             Schedule schedule = schedulePost.getSchedule();
             City city = schedulePost.getCity();
             List<Theme> themes = schedule.getScheduleThemas().stream()

--- a/src/main/java/com/cocodan/triplan/post/schedule/service/SchedulePostService.java
+++ b/src/main/java/com/cocodan/triplan/post/schedule/service/SchedulePostService.java
@@ -9,7 +9,7 @@ import com.cocodan.triplan.member.service.MemberService;
 import com.cocodan.triplan.post.schedule.vo.SchedulePostSortingRule;
 import com.cocodan.triplan.schedule.domain.Schedule;
 import com.cocodan.triplan.schedule.domain.ScheduleThema;
-import com.cocodan.triplan.schedule.domain.vo.Thema;
+import com.cocodan.triplan.schedule.domain.vo.Theme;
 import com.cocodan.triplan.schedule.repository.ScheduleRepository;
 import com.cocodan.triplan.schedule.service.ScheduleService;
 import com.cocodan.triplan.spot.domain.vo.City;
@@ -69,7 +69,7 @@ public class SchedulePostService {
     public List<SchedulePostResponse> getSchedulePostList(
             String search,
             City city,
-            Thema theme,
+            Theme theme,
             SchedulePostSortingRule sortRule,
             Integer pageIndex
     ) {
@@ -140,7 +140,7 @@ public class SchedulePostService {
             MemberGetOneResponse memberResponse = memberService.getOne(schedulePost.getMemberId());
             Schedule schedule = schedulePost.getSchedule();
             City city = schedulePost.getCity();
-            List<Thema> themes = schedule.getScheduleThemas().stream()
+            List<Theme> themes = schedule.getScheduleThemas().stream()
                     .map(ScheduleThema::getThema).collect(Collectors.toList());
             String title = schedulePost.getTitle();
 

--- a/src/main/java/com/cocodan/triplan/post/schedule/vo/Ages.java
+++ b/src/main/java/com/cocodan/triplan/post/schedule/vo/Ages.java
@@ -33,7 +33,7 @@ public enum Ages {
             case 3:
                 return Ages.THIRTIES;
             case 4:
-                return Ages.FIFTIES;
+                return Ages.FORTIES;
             case 5:
                 return Ages.FIFTIES;
             case 6:

--- a/src/main/java/com/cocodan/triplan/schedule/domain/ScheduleThema.java
+++ b/src/main/java/com/cocodan/triplan/schedule/domain/ScheduleThema.java
@@ -1,6 +1,6 @@
 package com.cocodan.triplan.schedule.domain;
 
-import com.cocodan.triplan.schedule.domain.vo.Thema;
+import com.cocodan.triplan.schedule.domain.vo.Theme;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
@@ -21,13 +21,13 @@ public class ScheduleThema {
     private Schedule schedule;
 
     @Enumerated(value = EnumType.STRING)
-    @Column(name = "tag")
-    private Thema thema;
+    @Column(name = "theme")
+    private Theme theme;
 
     @Builder
-    public ScheduleThema(Schedule schedule, Thema thema) {
+    public ScheduleThema(Schedule schedule, Theme theme) {
         this.schedule = schedule;
-        this.thema = thema;
+        this.theme = theme;
         this.schedule.getScheduleThemas().add(this);
     }
 
@@ -35,8 +35,8 @@ public class ScheduleThema {
         return id;
     }
 
-    public Thema getThema() {
-        return thema;
+    public Theme getThema() {
+        return theme;
     }
 
     public Schedule getSchedule() {

--- a/src/main/java/com/cocodan/triplan/schedule/domain/vo/Theme.java
+++ b/src/main/java/com/cocodan/triplan/schedule/domain/vo/Theme.java
@@ -3,7 +3,7 @@ package com.cocodan.triplan.schedule.domain.vo;
 import lombok.Getter;
 
 @Getter
-public enum Thema {
+public enum Theme {
 
     ACTIVITY("ACTIVITY"),
     FOOD("FOOD"),
@@ -14,7 +14,7 @@ public enum Thema {
 
     private String value;
 
-    Thema(String value) {
+    Theme(String value) {
         this.value = value;
     }
 }

--- a/src/main/java/com/cocodan/triplan/schedule/dto/response/DailyScheduleSpotResponse.java
+++ b/src/main/java/com/cocodan/triplan/schedule/dto/response/DailyScheduleSpotResponse.java
@@ -17,7 +17,7 @@ public class DailyScheduleSpotResponse {
 
     private LocalDate date;
 
-    private Integer order;
+    private int order;
 
     public static DailyScheduleSpotResponse from(DailyScheduleSpot dailyScheduleSpot) {
         return DailyScheduleSpotResponse.builder()
@@ -32,11 +32,6 @@ public class DailyScheduleSpotResponse {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         DailyScheduleSpotResponse that = (DailyScheduleSpotResponse) o;
-        return spotId.equals(that.spotId) && date.equals(that.date) && order.equals(that.order);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(spotId, date, order);
+        return spotId.equals(that.spotId) && date.equals(that.date) && order == that.order;
     }
 }

--- a/src/main/java/com/cocodan/triplan/schedule/dto/response/DailyScheduleSpotResponse.java
+++ b/src/main/java/com/cocodan/triplan/schedule/dto/response/DailyScheduleSpotResponse.java
@@ -1,0 +1,42 @@
+package com.cocodan.triplan.schedule.dto.response;
+
+import com.cocodan.triplan.schedule.domain.DailyScheduleSpot;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.Objects;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class DailyScheduleSpotResponse {
+
+    private Long spotId;
+
+    private LocalDate date;
+
+    private Integer order;
+
+    public static DailyScheduleSpotResponse from(DailyScheduleSpot dailyScheduleSpot) {
+        return DailyScheduleSpotResponse.builder()
+                .spotId(dailyScheduleSpot.getSpotId())
+                .date(dailyScheduleSpot.getDate())
+                .order(dailyScheduleSpot.getOrder())
+                .build();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        DailyScheduleSpotResponse that = (DailyScheduleSpotResponse) o;
+        return spotId.equals(that.spotId) && date.equals(that.date) && order.equals(that.order);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(spotId, date, order);
+    }
+}

--- a/src/main/java/com/cocodan/triplan/schedule/dto/response/ScheduleDetailResponse.java
+++ b/src/main/java/com/cocodan/triplan/schedule/dto/response/ScheduleDetailResponse.java
@@ -1,6 +1,6 @@
 package com.cocodan.triplan.schedule.dto.response;
 
-import com.cocodan.triplan.schedule.domain.vo.Thema;
+import com.cocodan.triplan.schedule.domain.vo.Theme;
 import com.cocodan.triplan.spot.dto.response.SpotSimple;
 import lombok.Builder;
 import lombok.Getter;
@@ -10,22 +10,22 @@ import java.util.List;
 
 @Getter
 public class ScheduleDetailResponse {
-    private final Long id;
-    private final String title;
-    private final LocalDate startDate;
-    private final LocalDate endDate;
-    private final List<SpotSimple> spotSimpleList;
-    private final List<Thema> themas;
-    private final List<String> memberImageUrls;
+    private Long id;
+    private String title;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private List<SpotSimple> spotSimpleList;
+    private List<Theme> thema;
+    private List<String> memberImageUrls;
 
     @Builder
-    public ScheduleDetailResponse(Long id, String title, LocalDate startDate, LocalDate endDate, List<SpotSimple> spotSimpleList, List<Thema> themas, List<String> memberImageUrls) {
+    public ScheduleDetailResponse(Long id, String title, LocalDate startDate, LocalDate endDate, List<SpotSimple> spotSimpleList, List<Theme> thema, List<String> memberImageUrls) {
         this.id = id;
         this.title = title;
         this.startDate = startDate;
         this.endDate = endDate;
         this.spotSimpleList = spotSimpleList;
-        this.themas = themas;
+        this.thema = thema;
         this.memberImageUrls = memberImageUrls;
     }
 }

--- a/src/main/java/com/cocodan/triplan/schedule/dto/response/ScheduleSimpleResponse.java
+++ b/src/main/java/com/cocodan/triplan/schedule/dto/response/ScheduleSimpleResponse.java
@@ -1,6 +1,6 @@
 package com.cocodan.triplan.schedule.dto.response;
 
-import com.cocodan.triplan.schedule.domain.vo.Thema;
+import com.cocodan.triplan.schedule.domain.vo.Theme;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -10,14 +10,14 @@ import java.util.List;
 @Getter
 public class ScheduleSimpleResponse {
 
-    private final Long id;
-    private final String title;
-    private final LocalDate startDate;
-    private final LocalDate endDate;
-    private final List<Thema> themas;
+    private Long id;
+    private String title;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private List<Theme> themas;
 
     @Builder
-    public ScheduleSimpleResponse(Long id, String title, LocalDate startDate, LocalDate endDate, List<Thema> themas) {
+    public ScheduleSimpleResponse(Long id, String title, LocalDate startDate, LocalDate endDate, List<Theme> themas) {
         this.id = id;
         this.title = title;
         this.startDate = startDate;

--- a/src/test/java/com/cocodan/triplan/post/schedule/service/SchedulePostServiceTest.java
+++ b/src/test/java/com/cocodan/triplan/post/schedule/service/SchedulePostServiceTest.java
@@ -178,7 +178,8 @@ class SchedulePostServiceTest {
         assertThat(schedulePostDetail.getGender()).isEqualTo(post.getMember().getGender());
         assertThat(schedulePostDetail.getNickname()).isEqualTo(post.getMember().getNickname());
         assertThat(schedulePostDetail.getAges()).isEqualTo(Ages.from(post.getMember().getBirth()));
-        
+
+        // TODO: 2021.12.10 Teru - equals method를 오버라이드 하지 않고, 그냥 DTO의 toString() 을 통해서 String 비교로 검증하도록 수정.
         Assertions.assertArrayEquals(
                 schedulePostDetail.getDailyScheduleSpots().toArray(),
                 post.getSchedule().getDailyScheduleSpots().stream()

--- a/src/test/java/com/cocodan/triplan/post/schedule/service/SchedulePostServiceTest.java
+++ b/src/test/java/com/cocodan/triplan/post/schedule/service/SchedulePostServiceTest.java
@@ -4,13 +4,17 @@ import com.cocodan.triplan.member.domain.vo.GenderType;
 import com.cocodan.triplan.member.service.MemberService;
 import com.cocodan.triplan.post.schedule.domain.SchedulePost;
 import com.cocodan.triplan.post.schedule.dto.request.SchedulePostCreateRequest;
+import com.cocodan.triplan.post.schedule.dto.response.SchedulePostDetailResponse;
 import com.cocodan.triplan.post.schedule.dto.response.SchedulePostResponse;
+import com.cocodan.triplan.post.schedule.vo.Ages;
 import com.cocodan.triplan.post.schedule.vo.SchedulePostSortingRule;
 import com.cocodan.triplan.schedule.domain.vo.Theme;
 import com.cocodan.triplan.schedule.dto.request.DailyScheduleSpotCreationRequest;
 import com.cocodan.triplan.schedule.dto.request.ScheduleCreationRequest;
+import com.cocodan.triplan.schedule.dto.response.DailyScheduleSpotResponse;
 import com.cocodan.triplan.schedule.service.ScheduleService;
 import com.cocodan.triplan.spot.domain.vo.City;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -21,6 +25,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.*;
 
@@ -56,7 +61,7 @@ class SchedulePostServiceTest {
                 GENDER,
                 NICKNAME,
                 PROFILE_IMAGE
-                        ).getId();
+        ).getId();
     }
 
     @Test
@@ -77,7 +82,7 @@ class SchedulePostServiceTest {
         Long createdSchedulePostId = schedulePostService.createSchedulePost(testMemberId, request);
 
         // 여행 공유 게시글 조회
-        List<SchedulePostResponse> posts = schedulePostService.getSchedulePostList("", City.ALL, Theme.ALL, SchedulePostSortingRule.RECENT, 0);
+        List<SchedulePostResponse> posts = schedulePostService.getSchedulePosts("", City.ALL, Theme.ALL, SchedulePostSortingRule.RECENT, 0);
         assertThat(posts.size()).isEqualTo(1);
         assertThat(posts.get(0).getProfileImageUrl()).isEqualTo(PROFILE_IMAGE);
         assertThat(posts.get(0).getNickname()).isEqualTo(NICKNAME);
@@ -120,16 +125,65 @@ class SchedulePostServiceTest {
         Long createdSchedulePostId = schedulePostService.createSchedulePost(testMemberId, request);
         SchedulePost post1 = schedulePostService.findById(createdSchedulePostId);
 
-        assertThat(post1.getMemberId()).isEqualTo(testMemberId);
-        assertThat(memberService.getOne(post1.getMemberId()).getEmail()).isEqualTo(EMAIL);
-        assertThat(memberService.getOne(post1.getMemberId()).getName()).isEqualTo(NAME);
-        assertThat(memberService.getOne(post1.getMemberId()).getPhoneNumber()).isEqualTo(PHONE);
-        assertThat(memberService.getOne(post1.getMemberId()).getBirth()).isEqualTo(BIRTH);
-        assertThat(memberService.getOne(post1.getMemberId()).getNickname()).isEqualTo(NICKNAME);
-        assertThat(memberService.getOne(post1.getMemberId()).getProfileImage()).isEqualTo(PROFILE_IMAGE);
+        assertThat(post1.getMember().getId()).isEqualTo(testMemberId);
+        assertThat(memberService.getOne(post1.getMember().getId()).getEmail()).isEqualTo(EMAIL);
+        assertThat(memberService.getOne(post1.getMember().getId()).getName()).isEqualTo(NAME);
+        assertThat(memberService.getOne(post1.getMember().getId()).getPhoneNumber()).isEqualTo(PHONE);
+        assertThat(memberService.getOne(post1.getMember().getId()).getBirth()).isEqualTo(BIRTH);
+        assertThat(memberService.getOne(post1.getMember().getId()).getNickname()).isEqualTo(NICKNAME);
+        assertThat(memberService.getOne(post1.getMember().getId()).getProfileImage()).isEqualTo(PROFILE_IMAGE);
         assertThat(post1.getTitle()).isEqualTo("1번 여행!");
         assertThat(post1.getContent()).isEqualTo("어디로든 갔다옴~");
         assertThat(post1.getCity()).isEqualTo(City.SEOUL);
         assertThat(post1.getSchedule().getId()).isEqualTo(createdScheduleId);
+    }
+
+    @Test
+    @DisplayName("여행 공유 게시글을 상세 조회 할 수 있다.")
+    @Transactional
+    void getSchedulePostDetail() {
+        ScheduleCreationRequest scheduleCreationRequest = createScheduleCreation();
+        Long createdScheduleId = scheduleService.createSchedule(scheduleCreationRequest, testMemberId);
+        SchedulePostCreateRequest request = SchedulePostCreateRequest.builder()
+                .title("1번 여행!")
+                .content("Apple Inc. is an American multinational technology company that specializes in consumer electronics, computer software and online services. Apple is the largest information technology company by revenue (totaling $274.5 billion in 2020) and, since January 2021, the world's most valuable company. As of 2021, Apple is the fourth-largest PC vendor by unit sales[9] and fourth-largest smartphone manufacturer.[10][11] It is one of the Big Five American information technology companies, alongside Amazon, Google (Alphabet), Facebook (Meta), and Microsoft.[12][13][14]\n" +
+                        "\n" +
+                        "Apple was founded in 1976 by Steve Jobs, Steve Wozniak and Ronald Wayne to develop and sell Wozniak's Apple I personal computer. It was incorporated by Jobs and Wozniak as Apple Computer, Inc. in 1977, and sales of its computers, among them the Apple II, grew quickly. It went public in 1980, to instant financial success. Over the next few years, Apple shipped new computers featuring innovative graphical user interfaces, such as the original Macintosh, announced in a critically acclaimed advertisement, \"1984\", directed by Ridley Scott. The high cost of its products and limited application library caused problems, as did power struggles between executives. In 1985, Wozniak departed Apple amicably,[15] while Jobs resigned to found NeXT, taking some Apple employees with him.[16]\n" +
+                        "\n" +
+                        "As the market for personal computers expanded and evolved throughout the 1990s, Apple lost considerable market share to the lower-priced duopoly of Microsoft Windows on Intel PC clones. The board recruited CEO Gil Amelio, who prepared the struggling company for eventual success with extensive reforms, product focus and layoffs in his 500-day tenure. In 1997, Amelio bought NeXT to resolve Apple's unsuccessful operating-system strategy and entice Jobs back to the company; he replaced Amelio. Apple became profitable again through a number of tactics. First, a revitalizing campaign called \"Think different\", and by launching the iMac and iPod. In 2001, it opened a retail chain, the Apple Stores, and has acquired numerous companies to broaden its software portfolio. In 2007, the company launched the iPhone to critical acclaim and financial success. Jobs resigned in 2011 for health reasons, and died two months later. He was succeeded as CEO by Tim Cook.\n" +
+                        "\n" +
+                        "The company receives significant criticism regarding the labor practices of its contractors, its environmental practices, and its business ethics, including anti-competitive behavior and materials sourcing. In August 2018, Apple became the first publicly traded U.S. company to be valued at over $1 trillion,[17][18] and, two years later, the first valued at over $2 trillion.[19][20] The company enjoys a high level of brand loyalty, and is ranked as the world's most valuable brand; as of January 2021, there are 1.65 billion Apple products in active use.[21]")
+                .city("서울")
+                .scheduleId(createdScheduleId)
+                .build();
+        Long createdSchedulePostId = schedulePostService.createSchedulePost(testMemberId, request);
+        SchedulePost post = schedulePostService.findById(createdSchedulePostId);
+
+        SchedulePostDetailResponse schedulePostDetail = schedulePostService.getSchedulePostDetail(createdSchedulePostId);
+
+        assertThat(schedulePostDetail.getTitle()).isEqualTo("1번 여행!");
+        assertThat(schedulePostDetail.getContent()).isEqualTo("Apple Inc. is an American multinational technology company that specializes in consumer electronics, computer software and online services. Apple is the largest information technology company by revenue (totaling $274.5 billion in 2020) and, since January 2021, the world's most valuable company. As of 2021, Apple is the fourth-largest PC vendor by unit sales[9] and fourth-largest smartphone manufacturer.[10][11] It is one of the Big Five American information technology companies, alongside Amazon, Google (Alphabet), Facebook (Meta), and Microsoft.[12][13][14]\n" +
+                "\n" +
+                "Apple was founded in 1976 by Steve Jobs, Steve Wozniak and Ronald Wayne to develop and sell Wozniak's Apple I personal computer. It was incorporated by Jobs and Wozniak as Apple Computer, Inc. in 1977, and sales of its computers, among them the Apple II, grew quickly. It went public in 1980, to instant financial success. Over the next few years, Apple shipped new computers featuring innovative graphical user interfaces, such as the original Macintosh, announced in a critically acclaimed advertisement, \"1984\", directed by Ridley Scott. The high cost of its products and limited application library caused problems, as did power struggles between executives. In 1985, Wozniak departed Apple amicably,[15] while Jobs resigned to found NeXT, taking some Apple employees with him.[16]\n" +
+                "\n" +
+                "As the market for personal computers expanded and evolved throughout the 1990s, Apple lost considerable market share to the lower-priced duopoly of Microsoft Windows on Intel PC clones. The board recruited CEO Gil Amelio, who prepared the struggling company for eventual success with extensive reforms, product focus and layoffs in his 500-day tenure. In 1997, Amelio bought NeXT to resolve Apple's unsuccessful operating-system strategy and entice Jobs back to the company; he replaced Amelio. Apple became profitable again through a number of tactics. First, a revitalizing campaign called \"Think different\", and by launching the iMac and iPod. In 2001, it opened a retail chain, the Apple Stores, and has acquired numerous companies to broaden its software portfolio. In 2007, the company launched the iPhone to critical acclaim and financial success. Jobs resigned in 2011 for health reasons, and died two months later. He was succeeded as CEO by Tim Cook.\n" +
+                "\n" +
+                "The company receives significant criticism regarding the labor practices of its contractors, its environmental practices, and its business ethics, including anti-competitive behavior and materials sourcing. In August 2018, Apple became the first publicly traded U.S. company to be valued at over $1 trillion,[17][18] and, two years later, the first valued at over $2 trillion.[19][20] The company enjoys a high level of brand loyalty, and is ranked as the world's most valuable brand; as of January 2021, there are 1.65 billion Apple products in active use.[21]");
+        assertThat(schedulePostDetail.getCity()).isEqualTo(City.SEOUL);
+        assertThat(schedulePostDetail.getCreatedAt()).isEqualTo(post.getCreatedDate());
+        assertThat(schedulePostDetail.getViews()).isEqualTo(post.getViews());
+        assertThat(schedulePostDetail.getLiked()).isEqualTo(post.getLiked());
+        assertThat(schedulePostDetail.getStartDate()).isEqualTo(post.getSchedule().getStartDate());
+        assertThat(schedulePostDetail.getEndDate()).isEqualTo(post.getSchedule().getEndDate());
+        assertThat(schedulePostDetail.getGender()).isEqualTo(post.getMember().getGender());
+        assertThat(schedulePostDetail.getNickname()).isEqualTo(post.getMember().getNickname());
+        assertThat(schedulePostDetail.getAges()).isEqualTo(Ages.from(post.getMember().getBirth()));
+        
+        Assertions.assertArrayEquals(
+                schedulePostDetail.getDailyScheduleSpots().toArray(),
+                post.getSchedule().getDailyScheduleSpots().stream()
+                        .map(DailyScheduleSpotResponse::from)
+                        .toArray()
+                );
     }
 }

--- a/src/test/java/com/cocodan/triplan/post/schedule/service/SchedulePostServiceTest.java
+++ b/src/test/java/com/cocodan/triplan/post/schedule/service/SchedulePostServiceTest.java
@@ -6,7 +6,7 @@ import com.cocodan.triplan.post.schedule.domain.SchedulePost;
 import com.cocodan.triplan.post.schedule.dto.request.SchedulePostCreateRequest;
 import com.cocodan.triplan.post.schedule.dto.response.SchedulePostResponse;
 import com.cocodan.triplan.post.schedule.vo.SchedulePostSortingRule;
-import com.cocodan.triplan.schedule.domain.vo.Thema;
+import com.cocodan.triplan.schedule.domain.vo.Theme;
 import com.cocodan.triplan.schedule.dto.request.DailyScheduleSpotCreationRequest;
 import com.cocodan.triplan.schedule.dto.request.ScheduleCreationRequest;
 import com.cocodan.triplan.schedule.service.ScheduleService;
@@ -63,7 +63,6 @@ class SchedulePostServiceTest {
     @DisplayName("생성된 여행 공유 게시글 리스트를 정상적으로 조회 할 수 있다.")
     @Transactional
     void getRecentSchedulePostList() {
-        // TODO: 2012.12.07 Teru - 게시글 조회 테스트 추가
         // 여행 생성
         ScheduleCreationRequest scheduleCreationRequest = createScheduleCreation();
         Long createdScheduleId = scheduleService.createSchedule(scheduleCreationRequest, testMemberId);
@@ -78,7 +77,7 @@ class SchedulePostServiceTest {
         Long createdSchedulePostId = schedulePostService.createSchedulePost(testMemberId, request);
 
         // 여행 공유 게시글 조회
-        List<SchedulePostResponse> posts = schedulePostService.getSchedulePostList("", City.ALL, Thema.ALL, SchedulePostSortingRule.RECENT, 0);
+        List<SchedulePostResponse> posts = schedulePostService.getSchedulePostList("", City.ALL, Theme.ALL, SchedulePostSortingRule.RECENT, 0);
         assertThat(posts.size()).isEqualTo(1);
         assertThat(posts.get(0).getProfileImageUrl()).isEqualTo(PROFILE_IMAGE);
         assertThat(posts.get(0).getNickname()).isEqualTo(NICKNAME);
@@ -87,7 +86,9 @@ class SchedulePostServiceTest {
         assertThat(posts.get(0).getCity()).isEqualTo(City.SEOUL);
         assertThat(posts.get(0).getStartDate()).isEqualTo(LocalDate.of(2021, 12, 1));
         assertThat(posts.get(0).getEndDate()).isEqualTo(LocalDate.of(2021, 12, 3));
-        assertThat(posts.get(0).getThemes()).contains(Thema.ACTIVITY, Thema.FOOD);
+        assertThat(posts.get(0).getThema()).contains(Theme.ACTIVITY, Theme.FOOD);
+
+        // TODO: 다양한 조건으로 테스트 추가
     }
 
     private ScheduleCreationRequest createScheduleCreation() {

--- a/src/test/java/com/cocodan/triplan/schedule/service/ScheduleServiceTest.java
+++ b/src/test/java/com/cocodan/triplan/schedule/service/ScheduleServiceTest.java
@@ -3,13 +3,14 @@ package com.cocodan.triplan.schedule.service;
 import com.cocodan.triplan.member.dto.response.MemberCreateResponse;
 import com.cocodan.triplan.member.service.MemberService;
 import com.cocodan.triplan.schedule.domain.*;
-import com.cocodan.triplan.schedule.domain.vo.Thema;
+import com.cocodan.triplan.schedule.domain.vo.Theme;
 import com.cocodan.triplan.schedule.dto.request.*;
 import com.cocodan.triplan.schedule.dto.response.*;
 import com.cocodan.triplan.schedule.repository.ChecklistRepository;
 import com.cocodan.triplan.schedule.repository.MemoRepository;
 import com.cocodan.triplan.schedule.repository.ScheduleRepository;
 import com.cocodan.triplan.schedule.repository.VotingRepository;
+import com.cocodan.triplan.spot.dto.response.SpotSimple;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -95,9 +96,9 @@ class ScheduleServiceTest {
 
         assertThat(schedule.getStartDate()).isEqualTo(LocalDate.of(2021, 12, 1));
         assertThat(schedule.getTitle()).isEqualTo("title");
-        assertThat(schedule.getThemas()).contains(Thema.valueOf("ACTIVITY"), Thema.valueOf("FOOD"));
+        assertThat(schedule.getThema()).contains(Theme.valueOf("ACTIVITY"), Theme.valueOf("FOOD"));
         List<Long> ids = schedule.getSpotSimpleList().stream()
-                .map(spotSimple -> spotSimple.getId())
+                .map(SpotSimple::getId)
                 .collect(Collectors.toList());
 
         // TODO: 장소 데이터 추가되면 다시 확인
@@ -129,7 +130,7 @@ class ScheduleServiceTest {
         Schedule updatedSchedule = scheduleRepository.findById(schedule).get();
 
         List<Long> ids = updatedSchedule.getDailyScheduleSpots().stream()
-                .map(dailyScheduleSpot -> dailyScheduleSpot.getSpotId())
+                .map(DailyScheduleSpot::getSpotId)
                 .collect(Collectors.toList());
 
         assertThat(ids).containsExactlyInAnyOrder(5L, 6L, 7L, 8L, 9L, 11L, 12L);
@@ -306,7 +307,7 @@ class ScheduleServiceTest {
 
         List<String> contentList = savedVoting.getVotingContents()
                 .stream()
-                .map(votingContent -> votingContent.getContent())
+                .map(VotingContent::getContent)
                 .collect(Collectors.toList());
 
         // Then


### PR DESCRIPTION
* Member와 Schedule 정보가 필요한 경우가 있어서 기존에 SchedulePost에서 memberId, scheduleId만 갖고 있던 것을 Member 와 Schedule을 갖고 있도록 해 두었습니다.
* 추후 다시 Id값만 가지고 있는 상태로 돌릴 수 있다고 생각되면 다시 기존처럼 돌리려고 합니다.