### PR TITLE
[TP-63] 여행 공유 게시글에 좋아요 누르기 API 구현

### DIFF
--- a/src/main/java/com/cocodan/triplan/post/schedule/controller/SchedulePostController.java
+++ b/src/main/java/com/cocodan/triplan/post/schedule/controller/SchedulePostController.java
@@ -2,9 +2,11 @@ package com.cocodan.triplan.post.schedule.controller;
 
 import com.cocodan.triplan.member.domain.Member;
 import com.cocodan.triplan.member.domain.vo.GenderType;
+import com.cocodan.triplan.post.schedule.dto.request.SchedulePostLikeRequest;
 import com.cocodan.triplan.post.schedule.dto.request.SchedulePostRequest;
 import com.cocodan.triplan.post.schedule.dto.response.SchedulePostCreateResponse;
 import com.cocodan.triplan.post.schedule.dto.response.SchedulePostDetailResponse;
+import com.cocodan.triplan.post.schedule.dto.response.SchedulePostLikeResponse;
 import com.cocodan.triplan.post.schedule.dto.response.SchedulePostResponse;
 import com.cocodan.triplan.post.schedule.service.SchedulePostService;
 import com.cocodan.triplan.post.schedule.vo.SchedulePostSortingRule;
@@ -102,4 +104,16 @@ public class SchedulePostController {
         schedulePostService.modifySchedulePost(member.getId(), request);
         return ResponseEntity.ok().build();
     }
+
+    @ApiOperation("여행 공유 게시글 좋아요 토글")
+    @PostMapping("/schedules/{schedulePostId}/liked")
+    public ResponseEntity<SchedulePostLikeResponse> changeLikeFlag(@PathVariable("schedulePostId") Long schedulePostId, @RequestBody SchedulePostLikeRequest request) {
+        // Member member = (Member) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        // TODO: TP-68 티켓에 의한 임시 코드 -> 추후 위의 comment-out 된 것으로 다시 교체
+        Member member = new Member(1L, "Temporary@temp.com", "Temporary User", "01011110000", "19000101", GenderType.MALE, "Temporary", "https://Temporary.temp.tem/img/temp-1");
+
+        Long likeCount = schedulePostService.toggleSchedulePostLiked(member.getId(), request);
+        return ResponseEntity.ok(new SchedulePostLikeResponse(likeCount));
+    }
+
 }

--- a/src/main/java/com/cocodan/triplan/post/schedule/domain/SchedulePost.java
+++ b/src/main/java/com/cocodan/triplan/post/schedule/domain/SchedulePost.java
@@ -47,17 +47,17 @@ public class SchedulePost extends BaseEntity {
     private String content;
 
     @Column(name = "views", nullable = false)
-    private Long views;
+    private long views;
 
     @Column(name = "liked", nullable = false)
-    private Long liked;
+    private long liked;
 
     @Column(name = "city", nullable = false)
     @Enumerated(EnumType.STRING)
     private City city;
 
     @Builder
-    public SchedulePost(Member member, Schedule schedule, String title, String content, Long views, Long liked, City city) {
+    public SchedulePost(Member member, Schedule schedule, String title, String content, long views, long liked, City city) {
         this.member = member;
         this.schedule = schedule;
         this.title = title;
@@ -77,5 +77,17 @@ public class SchedulePost extends BaseEntity {
 
     public void updateCity(City city) {
         this.city = city;
+    }
+
+    public void increaseViews() {
+        views++;
+    }
+
+    public long increaseLiked() {
+        return ++liked;
+    }
+
+    public long decreaseLiked() {
+        return --liked;
     }
 }

--- a/src/main/java/com/cocodan/triplan/post/schedule/dto/request/SchedulePostLikeRequest.java
+++ b/src/main/java/com/cocodan/triplan/post/schedule/dto/request/SchedulePostLikeRequest.java
@@ -1,0 +1,13 @@
+package com.cocodan.triplan.post.schedule.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SchedulePostLikeRequest {
+
+    private Long schedulePostId;
+
+    private Boolean flag;
+}

--- a/src/main/java/com/cocodan/triplan/post/schedule/dto/response/SchedulePostLikeResponse.java
+++ b/src/main/java/com/cocodan/triplan/post/schedule/dto/response/SchedulePostLikeResponse.java
@@ -1,0 +1,10 @@
+package com.cocodan.triplan.post.schedule.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SchedulePostLikeResponse {
+    private long likeCount;
+}

--- a/src/main/java/com/cocodan/triplan/post/schedule/repository/SchedulePostLikeRepository.java
+++ b/src/main/java/com/cocodan/triplan/post/schedule/repository/SchedulePostLikeRepository.java
@@ -1,0 +1,13 @@
+package com.cocodan.triplan.post.schedule.repository;
+
+import com.cocodan.triplan.post.schedule.domain.Like;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
+
+public interface SchedulePostLikeRepository extends JpaRepository<Like, Long> {
+
+    @Query("select l from Like l where l.memberId = :memberId and l.schedulePost.id = :schedulePostId")
+    Optional<Like> findByMemberIdAndSchedulePostId(Long memberId, Long schedulePostId);
+}

--- a/src/main/java/com/cocodan/triplan/post/schedule/repository/SchedulePostRepository.java
+++ b/src/main/java/com/cocodan/triplan/post/schedule/repository/SchedulePostRepository.java
@@ -4,8 +4,12 @@ import com.cocodan.triplan.post.schedule.domain.SchedulePost;
 import com.cocodan.triplan.spot.domain.vo.City;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 
+import javax.persistence.LockModeType;
 import java.util.List;
+import java.util.Optional;
 
 public interface SchedulePostRepository extends JpaRepository<SchedulePost, Long> {
 
@@ -19,4 +23,8 @@ public interface SchedulePostRepository extends JpaRepository<SchedulePost, Long
     List<SchedulePost> findAllByCityOrderByViewsDesc(City city, Pageable pageable);
     List<SchedulePost> findAllByCityAndTitleOrContentContainingOrderByCreatedDateDesc(City city, String title, String content, Pageable pageable);
     List<SchedulePost> findAllByCityAndTitleOrContentContainingOrderByViewsDesc(City city, String title, String content, Pageable pageable);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select sp from SchedulePost sp where sp.schedule.id = :schedulePostId")
+    Optional<SchedulePost> findByIdForLikedCountUpdate(Long schedulePostId);
 }

--- a/src/main/java/com/cocodan/triplan/post/schedule/repository/SchedulePostRepository.java
+++ b/src/main/java/com/cocodan/triplan/post/schedule/repository/SchedulePostRepository.java
@@ -25,6 +25,6 @@ public interface SchedulePostRepository extends JpaRepository<SchedulePost, Long
     List<SchedulePost> findAllByCityAndTitleOrContentContainingOrderByViewsDesc(City city, String title, String content, Pageable pageable);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @Query("select sp from SchedulePost sp where sp.schedule.id = :schedulePostId")
+    @Query("select sp from SchedulePost sp where sp.id = :schedulePostId")
     Optional<SchedulePost> findByIdForLikedCountUpdate(Long schedulePostId);
 }

--- a/src/main/java/com/cocodan/triplan/post/schedule/service/SchedulePostService.java
+++ b/src/main/java/com/cocodan/triplan/post/schedule/service/SchedulePostService.java
@@ -3,10 +3,13 @@ package com.cocodan.triplan.post.schedule.service;
 import com.cocodan.triplan.member.domain.Member;
 import com.cocodan.triplan.member.dto.response.MemberGetOneResponse;
 import com.cocodan.triplan.member.repository.MemberRepository;
+import com.cocodan.triplan.post.schedule.domain.Like;
 import com.cocodan.triplan.post.schedule.domain.SchedulePost;
+import com.cocodan.triplan.post.schedule.dto.request.SchedulePostLikeRequest;
 import com.cocodan.triplan.post.schedule.dto.request.SchedulePostRequest;
 import com.cocodan.triplan.post.schedule.dto.response.SchedulePostDetailResponse;
 import com.cocodan.triplan.post.schedule.dto.response.SchedulePostResponse;
+import com.cocodan.triplan.post.schedule.repository.SchedulePostLikeRepository;
 import com.cocodan.triplan.post.schedule.repository.SchedulePostRepository;
 import com.cocodan.triplan.member.service.MemberService;
 import com.cocodan.triplan.post.schedule.vo.SchedulePostSortingRule;
@@ -14,7 +17,6 @@ import com.cocodan.triplan.schedule.domain.Schedule;
 import com.cocodan.triplan.schedule.domain.ScheduleTheme;
 import com.cocodan.triplan.schedule.domain.vo.Theme;
 import com.cocodan.triplan.schedule.repository.ScheduleRepository;
-import com.cocodan.triplan.schedule.service.ScheduleService;
 import com.cocodan.triplan.spot.domain.vo.City;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
@@ -22,6 +24,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -34,12 +37,20 @@ public class SchedulePostService {
     private final MemberRepository memberRepository;
     private final ScheduleRepository scheduleRepository;
 
+    private final SchedulePostLikeRepository schedulePostLikeRepository;
+
     private final SchedulePostRepository schedulePostRepository;
 
-    public SchedulePostService(MemberService memberService, ScheduleService scheduleService, MemberRepository memberRepository, ScheduleRepository scheduleRepository, SchedulePostRepository schedulePostRepository) {
+    public SchedulePostService(
+            MemberService memberService,
+            MemberRepository memberRepository,
+            ScheduleRepository scheduleRepository,
+            SchedulePostLikeRepository schedulePostLikeRepository,
+            SchedulePostRepository schedulePostRepository) {
         this.memberService = memberService;
         this.memberRepository = memberRepository;
         this.scheduleRepository = scheduleRepository;
+        this.schedulePostLikeRepository = schedulePostLikeRepository;
         this.schedulePostRepository = schedulePostRepository;
     }
 
@@ -145,7 +156,8 @@ public class SchedulePostService {
         SchedulePost schedulePost = schedulePostRepository.findById(postId).orElseThrow(
                 () -> new RuntimeException("No such post found (ID : " + postId + ")")
         );
-
+        // TODO: 2021.12.13 Teru - 조회수에 대한 동시성 문제를 어떻게 해야 잘 해결할 수 있을지 고민... 현재는 별다른 처리를 해두지 않은 상태
+        schedulePost.increaseViews();
         return SchedulePostDetailResponse.from(schedulePost);
     }
 
@@ -197,5 +209,30 @@ public class SchedulePostService {
         schedulePost.updateCity(City.from(request.getCity()));
 
         schedulePostRepository.save(schedulePost);
+    }
+
+    @Transactional
+    public Long toggleSchedulePostLiked(Long memberId, SchedulePostLikeRequest request) {
+        // TODO: 2021.12.13 Teru - 좋아요 수에 대한 동시성 문제를 어떻게하면 더 잘 해결할 수 있을지 고민...
+        Long schedulePostId = request.getSchedulePostId();
+        Optional<Like> likeData =
+                schedulePostLikeRepository.findByMemberIdAndSchedulePostId(memberId, schedulePostId);
+        SchedulePost post = schedulePostRepository.findByIdForLikedCountUpdate(schedulePostId).orElseThrow(
+                () -> new RuntimeException("No such schedule post found (ID : " + schedulePostId + ")")
+        );
+
+        if (likeData.isEmpty() && request.getFlag()) {
+            Like like = new Like(memberId, post);
+            schedulePostLikeRepository.save(like);
+            return post.increaseLiked();
+        }
+
+        if (likeData.isPresent() && !request.getFlag()) {
+            schedulePostLikeRepository.delete(likeData.get());
+            return post.decreaseLiked();
+        }
+
+        // Invalid Like toggle
+        return post.getLiked();
     }
 }

--- a/src/main/java/com/cocodan/triplan/post/schedule/service/SchedulePostService.java
+++ b/src/main/java/com/cocodan/triplan/post/schedule/service/SchedulePostService.java
@@ -78,7 +78,7 @@ public class SchedulePostService {
                 .build();
 
         SchedulePost savedSchedulePost = schedulePostRepository.save(post);
-        return savedSchedulePost.getSchedule().getId();
+        return savedSchedulePost.getId();
     }
 
     @Transactional(readOnly = true)

--- a/src/test/java/com/cocodan/triplan/post/schedule/service/SchedulePostServiceTest.java
+++ b/src/test/java/com/cocodan/triplan/post/schedule/service/SchedulePostServiceTest.java
@@ -3,6 +3,7 @@ package com.cocodan.triplan.post.schedule.service;
 import com.cocodan.triplan.member.domain.vo.GenderType;
 import com.cocodan.triplan.member.service.MemberService;
 import com.cocodan.triplan.post.schedule.domain.SchedulePost;
+import com.cocodan.triplan.post.schedule.dto.request.SchedulePostLikeRequest;
 import com.cocodan.triplan.post.schedule.dto.request.SchedulePostRequest;
 import com.cocodan.triplan.post.schedule.dto.response.SchedulePostDetailResponse;
 import com.cocodan.triplan.post.schedule.dto.response.SchedulePostResponse;
@@ -43,6 +44,9 @@ class SchedulePostServiceTest {
     MemberService memberService;
 
     private static Long testMemberId;
+
+    private static Long createdScheduleId;
+
     private static final String EMAIL = "KimLeePark@gmail.com";
     private static final String NAME = "김이박";
     private static final String PHONE = "01077775555";
@@ -109,6 +113,24 @@ class SchedulePostServiceTest {
                 ));
     }
 
+    private Long createSchedulePost1() {
+        ScheduleCreationRequest scheduleCreationRequest = createScheduleCreation();
+        createdScheduleId = scheduleService.saveSchedule(scheduleCreationRequest, testMemberId);
+        SchedulePostRequest request = SchedulePostRequest.builder()
+                .title("1번 여행!")
+                .content("Apple Inc. is an American multinational technology company that specializes in consumer electronics, computer software and online services. Apple is the largest information technology company by revenue (totaling $274.5 billion in 2020) and, since January 2021, the world's most valuable company. As of 2021, Apple is the fourth-largest PC vendor by unit sales[9] and fourth-largest smartphone manufacturer.[10][11] It is one of the Big Five American information technology companies, alongside Amazon, Google (Alphabet), Facebook (Meta), and Microsoft.[12][13][14]\n" +
+                        "\n" +
+                        "Apple was founded in 1976 by Steve Jobs, Steve Wozniak and Ronald Wayne to develop and sell Wozniak's Apple I personal computer. It was incorporated by Jobs and Wozniak as Apple Computer, Inc. in 1977, and sales of its computers, among them the Apple II, grew quickly. It went public in 1980, to instant financial success. Over the next few years, Apple shipped new computers featuring innovative graphical user interfaces, such as the original Macintosh, announced in a critically acclaimed advertisement, \"1984\", directed by Ridley Scott. The high cost of its products and limited application library caused problems, as did power struggles between executives. In 1985, Wozniak departed Apple amicably,[15] while Jobs resigned to found NeXT, taking some Apple employees with him.[16]\n" +
+                        "\n" +
+                        "As the market for personal computers expanded and evolved throughout the 1990s, Apple lost considerable market share to the lower-priced duopoly of Microsoft Windows on Intel PC clones. The board recruited CEO Gil Amelio, who prepared the struggling company for eventual success with extensive reforms, product focus and layoffs in his 500-day tenure. In 1997, Amelio bought NeXT to resolve Apple's unsuccessful operating-system strategy and entice Jobs back to the company; he replaced Amelio. Apple became profitable again through a number of tactics. First, a revitalizing campaign called \"Think different\", and by launching the iMac and iPod. In 2001, it opened a retail chain, the Apple Stores, and has acquired numerous companies to broaden its software portfolio. In 2007, the company launched the iPhone to critical acclaim and financial success. Jobs resigned in 2011 for health reasons, and died two months later. He was succeeded as CEO by Tim Cook.\n" +
+                        "\n" +
+                        "The company receives significant criticism regarding the labor practices of its contractors, its environmental practices, and its business ethics, including anti-competitive behavior and materials sourcing. In August 2018, Apple became the first publicly traded U.S. company to be valued at over $1 trillion,[17][18] and, two years later, the first valued at over $2 trillion.[19][20] The company enjoys a high level of brand loyalty, and is ranked as the world's most valuable brand; as of January 2021, there are 1.65 billion Apple products in active use.[21]")
+                .city("서울")
+                .scheduleId(createdScheduleId)
+                .build();
+        return schedulePostService.createSchedulePost(testMemberId, request);
+    }
+
     @Test
     @DisplayName("여행 공유 게시글 생성 로직이 정상적으로 동작한다.")
     @Transactional
@@ -142,22 +164,9 @@ class SchedulePostServiceTest {
     @DisplayName("여행 공유 게시글을 상세 조회 할 수 있다.")
     @Transactional
     void getSchedulePostDetail() {
-        ScheduleCreationRequest scheduleCreationRequest = createScheduleCreation();
-        Long createdScheduleId = scheduleService.saveSchedule(scheduleCreationRequest, testMemberId);
-        SchedulePostRequest request = SchedulePostRequest.builder()
-                .title("1번 여행!")
-                .content("Apple Inc. is an American multinational technology company that specializes in consumer electronics, computer software and online services. Apple is the largest information technology company by revenue (totaling $274.5 billion in 2020) and, since January 2021, the world's most valuable company. As of 2021, Apple is the fourth-largest PC vendor by unit sales[9] and fourth-largest smartphone manufacturer.[10][11] It is one of the Big Five American information technology companies, alongside Amazon, Google (Alphabet), Facebook (Meta), and Microsoft.[12][13][14]\n" +
-                        "\n" +
-                        "Apple was founded in 1976 by Steve Jobs, Steve Wozniak and Ronald Wayne to develop and sell Wozniak's Apple I personal computer. It was incorporated by Jobs and Wozniak as Apple Computer, Inc. in 1977, and sales of its computers, among them the Apple II, grew quickly. It went public in 1980, to instant financial success. Over the next few years, Apple shipped new computers featuring innovative graphical user interfaces, such as the original Macintosh, announced in a critically acclaimed advertisement, \"1984\", directed by Ridley Scott. The high cost of its products and limited application library caused problems, as did power struggles between executives. In 1985, Wozniak departed Apple amicably,[15] while Jobs resigned to found NeXT, taking some Apple employees with him.[16]\n" +
-                        "\n" +
-                        "As the market for personal computers expanded and evolved throughout the 1990s, Apple lost considerable market share to the lower-priced duopoly of Microsoft Windows on Intel PC clones. The board recruited CEO Gil Amelio, who prepared the struggling company for eventual success with extensive reforms, product focus and layoffs in his 500-day tenure. In 1997, Amelio bought NeXT to resolve Apple's unsuccessful operating-system strategy and entice Jobs back to the company; he replaced Amelio. Apple became profitable again through a number of tactics. First, a revitalizing campaign called \"Think different\", and by launching the iMac and iPod. In 2001, it opened a retail chain, the Apple Stores, and has acquired numerous companies to broaden its software portfolio. In 2007, the company launched the iPhone to critical acclaim and financial success. Jobs resigned in 2011 for health reasons, and died two months later. He was succeeded as CEO by Tim Cook.\n" +
-                        "\n" +
-                        "The company receives significant criticism regarding the labor practices of its contractors, its environmental practices, and its business ethics, including anti-competitive behavior and materials sourcing. In August 2018, Apple became the first publicly traded U.S. company to be valued at over $1 trillion,[17][18] and, two years later, the first valued at over $2 trillion.[19][20] The company enjoys a high level of brand loyalty, and is ranked as the world's most valuable brand; as of January 2021, there are 1.65 billion Apple products in active use.[21]")
-                .city("서울")
-                .scheduleId(createdScheduleId)
-                .build();
-        Long createdSchedulePostId = schedulePostService.createSchedulePost(testMemberId, request);
+        Long createdSchedulePostId = createSchedulePost1();
         SchedulePost post = schedulePostService.findById(createdSchedulePostId);
+        long initialViews = post.getViews();
 
         SchedulePostDetailResponse schedulePostDetail = schedulePostService.getSchedulePostDetail(createdSchedulePostId);
 
@@ -172,6 +181,7 @@ class SchedulePostServiceTest {
         assertThat(schedulePostDetail.getCity()).isEqualTo(City.SEOUL);
         assertThat(schedulePostDetail.getCreatedAt()).isEqualTo(post.getCreatedDate());
         assertThat(schedulePostDetail.getViews()).isEqualTo(post.getViews());
+        assertThat(initialViews + 1).isEqualTo(post.getViews());
         assertThat(schedulePostDetail.getLiked()).isEqualTo(post.getLiked());
         assertThat(schedulePostDetail.getStartDate()).isEqualTo(post.getSchedule().getStartDate());
         assertThat(schedulePostDetail.getEndDate()).isEqualTo(post.getSchedule().getEndDate());
@@ -192,21 +202,7 @@ class SchedulePostServiceTest {
     @DisplayName("생성된 공유 게시글을 삭제할 수 있다")
     @Transactional
     void deleteSchedulePost() {
-        ScheduleCreationRequest scheduleCreationRequest = createScheduleCreation();
-        Long createdScheduleId = scheduleService.saveSchedule(scheduleCreationRequest, testMemberId);
-        SchedulePostRequest request = SchedulePostRequest.builder()
-                .title("1번 여행!")
-                .content("Apple Inc. is an American multinational technology company that specializes in consumer electronics, computer software and online services. Apple is the largest information technology company by revenue (totaling $274.5 billion in 2020) and, since January 2021, the world's most valuable company. As of 2021, Apple is the fourth-largest PC vendor by unit sales[9] and fourth-largest smartphone manufacturer.[10][11] It is one of the Big Five American information technology companies, alongside Amazon, Google (Alphabet), Facebook (Meta), and Microsoft.[12][13][14]\n" +
-                        "\n" +
-                        "Apple was founded in 1976 by Steve Jobs, Steve Wozniak and Ronald Wayne to develop and sell Wozniak's Apple I personal computer. It was incorporated by Jobs and Wozniak as Apple Computer, Inc. in 1977, and sales of its computers, among them the Apple II, grew quickly. It went public in 1980, to instant financial success. Over the next few years, Apple shipped new computers featuring innovative graphical user interfaces, such as the original Macintosh, announced in a critically acclaimed advertisement, \"1984\", directed by Ridley Scott. The high cost of its products and limited application library caused problems, as did power struggles between executives. In 1985, Wozniak departed Apple amicably,[15] while Jobs resigned to found NeXT, taking some Apple employees with him.[16]\n" +
-                        "\n" +
-                        "As the market for personal computers expanded and evolved throughout the 1990s, Apple lost considerable market share to the lower-priced duopoly of Microsoft Windows on Intel PC clones. The board recruited CEO Gil Amelio, who prepared the struggling company for eventual success with extensive reforms, product focus and layoffs in his 500-day tenure. In 1997, Amelio bought NeXT to resolve Apple's unsuccessful operating-system strategy and entice Jobs back to the company; he replaced Amelio. Apple became profitable again through a number of tactics. First, a revitalizing campaign called \"Think different\", and by launching the iMac and iPod. In 2001, it opened a retail chain, the Apple Stores, and has acquired numerous companies to broaden its software portfolio. In 2007, the company launched the iPhone to critical acclaim and financial success. Jobs resigned in 2011 for health reasons, and died two months later. He was succeeded as CEO by Tim Cook.\n" +
-                        "\n" +
-                        "The company receives significant criticism regarding the labor practices of its contractors, its environmental practices, and its business ethics, including anti-competitive behavior and materials sourcing. In August 2018, Apple became the first publicly traded U.S. company to be valued at over $1 trillion,[17][18] and, two years later, the first valued at over $2 trillion.[19][20] The company enjoys a high level of brand loyalty, and is ranked as the world's most valuable brand; as of January 2021, there are 1.65 billion Apple products in active use.[21]")
-                .city("서울")
-                .scheduleId(createdScheduleId)
-                .build();
-        Long createdSchedulePostId = schedulePostService.createSchedulePost(testMemberId, request);
+        Long createdSchedulePostId = createSchedulePost1();
         SchedulePost post = schedulePostService.findById(createdSchedulePostId);
 
         // 게시글 생성 확인
@@ -225,21 +221,7 @@ class SchedulePostServiceTest {
     @DisplayName("작성한 공유 게시글을 수정할 수 있다")
     @Transactional
     void modifySchedulePost() {
-        ScheduleCreationRequest scheduleCreationRequest = createScheduleCreation();
-        Long createdScheduleId = scheduleService.saveSchedule(scheduleCreationRequest, testMemberId);
-        SchedulePostRequest createRequest = SchedulePostRequest.builder()
-                .title("1번 여행!")
-                .content("Apple Inc. is an American multinational technology company that specializes in consumer electronics, computer software and online services. Apple is the largest information technology company by revenue (totaling $274.5 billion in 2020) and, since January 2021, the world's most valuable company. As of 2021, Apple is the fourth-largest PC vendor by unit sales[9] and fourth-largest smartphone manufacturer.[10][11] It is one of the Big Five American information technology companies, alongside Amazon, Google (Alphabet), Facebook (Meta), and Microsoft.[12][13][14]\n" +
-                        "\n" +
-                        "Apple was founded in 1976 by Steve Jobs, Steve Wozniak and Ronald Wayne to develop and sell Wozniak's Apple I personal computer. It was incorporated by Jobs and Wozniak as Apple Computer, Inc. in 1977, and sales of its computers, among them the Apple II, grew quickly. It went public in 1980, to instant financial success. Over the next few years, Apple shipped new computers featuring innovative graphical user interfaces, such as the original Macintosh, announced in a critically acclaimed advertisement, \"1984\", directed by Ridley Scott. The high cost of its products and limited application library caused problems, as did power struggles between executives. In 1985, Wozniak departed Apple amicably,[15] while Jobs resigned to found NeXT, taking some Apple employees with him.[16]\n" +
-                        "\n" +
-                        "As the market for personal computers expanded and evolved throughout the 1990s, Apple lost considerable market share to the lower-priced duopoly of Microsoft Windows on Intel PC clones. The board recruited CEO Gil Amelio, who prepared the struggling company for eventual success with extensive reforms, product focus and layoffs in his 500-day tenure. In 1997, Amelio bought NeXT to resolve Apple's unsuccessful operating-system strategy and entice Jobs back to the company; he replaced Amelio. Apple became profitable again through a number of tactics. First, a revitalizing campaign called \"Think different\", and by launching the iMac and iPod. In 2001, it opened a retail chain, the Apple Stores, and has acquired numerous companies to broaden its software portfolio. In 2007, the company launched the iPhone to critical acclaim and financial success. Jobs resigned in 2011 for health reasons, and died two months later. He was succeeded as CEO by Tim Cook.\n" +
-                        "\n" +
-                        "The company receives significant criticism regarding the labor practices of its contractors, its environmental practices, and its business ethics, including anti-competitive behavior and materials sourcing. In August 2018, Apple became the first publicly traded U.S. company to be valued at over $1 trillion,[17][18] and, two years later, the first valued at over $2 trillion.[19][20] The company enjoys a high level of brand loyalty, and is ranked as the world's most valuable brand; as of January 2021, there are 1.65 billion Apple products in active use.[21]")
-                .city("서울")
-                .scheduleId(createdScheduleId)
-                .build();
-        Long createdSchedulePostId = schedulePostService.createSchedulePost(testMemberId, createRequest);
+        Long createdSchedulePostId = createSchedulePost1();
         SchedulePost post = schedulePostService.findById(createdSchedulePostId);
 
         SchedulePostRequest modifyRequest = SchedulePostRequest.builder()
@@ -275,6 +257,27 @@ class SchedulePostServiceTest {
                 "\n" +
                 "삼성 그룹은 브랜드 파이낸스에서 선정하는 글로벌 브랜드가치순위 500대 기업에서 2018년 기준 4위에 올랐다. 브랜드 파이낸스는 매년 세계 기업의 브랜드가치를 평가하여 보고서를 작성, 브랜드가치 500대기업을 발표하고있는데, 브랜드 파이낸스는 2018년 삼성의 브랜드가치가 92289백만달러(약 104조원)의 가치를 지녔다고 평가했다.");
         assertThat(modifiedPost.getCity()).isEqualTo(City.BUSAN);
+    }
 
+    @Test
+    @DisplayName("작성된 공유 게시글에 좋아요 토글을 할 수 있다")
+    @Transactional
+    void toggleSchedulePostLiked() {
+        Long createdSchedulePostId = createSchedulePost1();
+        SchedulePost post = schedulePostService.findById(createdSchedulePostId);
+        // 좋아요 누르기 전 좋아요 수
+        long beforeLiked = post.getLiked();
+
+        // 좋아요 누르기
+        SchedulePostLikeRequest doSchedulePostLike = new SchedulePostLikeRequest(createdSchedulePostId, true);
+        Long afterLiked = schedulePostService.toggleSchedulePostLiked(testMemberId, doSchedulePostLike);
+        // 좋아요 취소
+        SchedulePostLikeRequest doSchedulePostLikeAgain = new SchedulePostLikeRequest(createdSchedulePostId, false);
+        Long afterLikedAgain = schedulePostService.toggleSchedulePostLiked(testMemberId, doSchedulePostLikeAgain);
+
+        // 좋아요 누른 후 좋아요 수
+        assertThat(beforeLiked + 1).isEqualTo(afterLiked);
+        // 좋아요 취소된 후 좋아요 수
+        assertThat(beforeLiked).isEqualTo(afterLikedAgain);
     }
 }


### PR DESCRIPTION
* 게시글에 좋아요, 좋아요 취소가 가능합니다.
* 현재 **좋아요 수 및 조회수**에 대한 동시성 문제가 심도있게 고려되지 않았습니다.
  * 좋아요 수에는 비관적 락을 적용 해 놓은 상태입니다. 보다 효율적인 해결방법 아이디어 있으시면 팍팍 말씀해주세요!
    * **비관락을 사용하는게 나을지**, 아니면 조회수 컬럼을 사용하지 않고 **좋아요 테이블에서 매번 count를 하는게 나을지**도 고민입니다.. 
  * **조회수에는 현재 아무런 조치도 취하지 않은 상태**입니다. 여기도 마찬가지로 효율적인 해결방법 아이디어 있으시면 팍팍 말씀해주세요!
    * 아무런 조치도 취하지 않은채로 둔 이유는 이렇습니다.
    * 조회수는 오로지 증가만 하고, 별도의 테이블이 있는 값이 아니다. 따라서 약간의 조회수 증가 누락이 있더라도 당장 치명적으로 작용하지는 않을 것 같다.
    * 좋아요 같은 경우에는 좋아요 요청이 올 때에만 게시글에 락이 걸리지만 조회수 같은 경우에 비관적 락을 걸면 조회 요청이 올 때 마다 락이 걸려서 여러 사람이 동시에 조회했을 때에도 FIFO로 조회를 해야 하며, 이 모든 시간동안 작성자는 이 글을 수정하거나 할 수 없어서 치명적일 것 같다.
* **기존 티켓 구현시 발생했던 로직 문제**를 발견하여 수정하였습니다. (SchedulePost 관련 정보를 다루어야 할 떄 Schedule 정보를 다루는 부분이 있었습니다.)