### PR TITLE
[TP-83] FIX: 12월 14일 오후 11시 develop 브랜치 기준 발견된 오류 수정

### DIFF
--- a/src/main/java/com/cocodan/triplan/post/schedule/controller/SchedulePostController.java
+++ b/src/main/java/com/cocodan/triplan/post/schedule/controller/SchedulePostController.java
@@ -106,7 +106,7 @@ public class SchedulePostController {
         // TODO: TP-68 티켓에 의한 임시 코드 -> 추후 위의 comment-out 된 것으로 다시 교체
         Member member = new Member(1L, "Temporary@temp.com", "Temporary User", "01011110000", "19000101", GenderType.MALE, "Temporary", "https://Temporary.temp.tem/img/temp-1");
 
-        schedulePostService.modifySchedulePost(member.getId(), request);
+        schedulePostService.modifySchedulePost(member.getId(), schedulePostId, request);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/cocodan/triplan/post/schedule/dto/response/SchedulePostCommentResponse.java
+++ b/src/main/java/com/cocodan/triplan/post/schedule/dto/response/SchedulePostCommentResponse.java
@@ -23,11 +23,14 @@ public class SchedulePostCommentResponse {
 
     private LocalDateTime createdAt;
 
+    private Long memberId;
+
     private boolean schedulePostWriter;
 
     public static SchedulePostCommentResponse of(SchedulePostComment comment, MemberGetOneResponse member, boolean schedulePostWriter) {
         return SchedulePostCommentResponse.builder()
                 .nickname(member.getNickname())
+                .memberId(member.getId())
                 .ages(Ages.from(member.getBirth()))
                 .gender(member.getGender())
                 .content(comment.getContent())

--- a/src/main/java/com/cocodan/triplan/post/schedule/service/SchedulePostService.java
+++ b/src/main/java/com/cocodan/triplan/post/schedule/service/SchedulePostService.java
@@ -143,9 +143,8 @@ public class SchedulePostService {
     }
 
     @Transactional
-    public void modifySchedulePost(Long memberId, SchedulePostRequest request) {
-        Long requestedSchedulePostId = request.getScheduleId();
-        SchedulePost schedulePost = validateAuthorities(memberId, requestedSchedulePostId);
+    public void modifySchedulePost(Long memberId, Long schedulePostId, SchedulePostRequest request) {
+        SchedulePost schedulePost = validateAuthorities(memberId, schedulePostId);
 
         schedulePost.updateTitle(request.getTitle());
         schedulePost.updateContent(request.getContent());

--- a/src/test/java/com/cocodan/triplan/post/schedule/service/SchedulePostServiceTest.java
+++ b/src/test/java/com/cocodan/triplan/post/schedule/service/SchedulePostServiceTest.java
@@ -301,10 +301,10 @@ class SchedulePostServiceTest {
         SchedulePost post = schedulePostService.findById(createdSchedulePostId);
 
         // 게시글 생성 확인
-        assertThat(schedulePostService.findById(createdSchedulePostId).getId()).isEqualTo(createdScheduleId);
+        assertThat(post.getId()).isEqualTo(createdSchedulePostId);
 
         // 게시글 삭제하기
-        schedulePostService.deleteSchedulePost(testMemberId, createdScheduleId);
+        schedulePostService.deleteSchedulePost(testMemberId, createdSchedulePostId);
 
         // 게시글이 삭제되었는지 검증하기
         Assertions.assertThrows(RuntimeException.class,
@@ -335,7 +335,7 @@ class SchedulePostServiceTest {
                 .city("부산")
                 .scheduleId(createdScheduleId)
                 .build();
-        schedulePostService.modifySchedulePost(testMemberId, modifyRequest);
+        schedulePostService.modifySchedulePost(testMemberId, post.getId(), modifyRequest);
 
         // assert
         SchedulePost modifiedPost = schedulePostService.findById(createdSchedulePostId);


### PR DESCRIPTION
* 테스트코드에 숨어있던 로직 오류를 수정하였습니다. (SchedulePostId가 사용되어야 하는 곳에 ScheduleId가 사용되고 있던 문제를 수정하였습니다.)
* 여행 공유 게시글 상세 조회시 댓글에 작성자의 memberId가 같이 반환되도록 수정하였습니다. (댓글을 통해 해당 유저의 프로필로 접근을 가능하게 할 것이면 이 수정본대로 하면 되고, 댓글을 통해서는 프로필 접근을 못하게 할 것이라면 기존처럼 memberId를 제외하고 보내주면 됩니다.)