### PR TITLE
[TP-93] 일정 응답 데이터 수정

### DIFF
--- a/src/main/java/com/cocodan/triplan/schedule/domain/Checklist.java
+++ b/src/main/java/com/cocodan/triplan/schedule/domain/Checklist.java
@@ -34,7 +34,7 @@ public class Checklist extends BaseEntity {
     private int day;
 
     @Builder
-    public Checklist(Schedule schedule, String title, int day) {
+    private Checklist(Schedule schedule, String title, int day) {
         this.schedule = schedule;
         this.title = title;
         this.day = day;

--- a/src/main/java/com/cocodan/triplan/schedule/domain/DailyScheduleSpot.java
+++ b/src/main/java/com/cocodan/triplan/schedule/domain/DailyScheduleSpot.java
@@ -6,7 +6,6 @@ import lombok.Builder;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
-import java.time.LocalDate;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -24,18 +23,18 @@ public class DailyScheduleSpot extends BaseEntity {
     @Column(name = "spotId", nullable = false)
     private Long spotId;
 
-    @Column(name = "trip_date", nullable = false)
-    private int date;
+    @Column(name = "date_order", nullable = false)
+    private int dateOrder;
 
-    @Column(name = "trip_order", nullable = false)
-    private int order;
+    @Column(name = "spot_order", nullable = false)
+    private int spotOrder;
 
     @Builder
-    public DailyScheduleSpot(Schedule schedule, Long spotId, int date, int order) {
+    private DailyScheduleSpot(Schedule schedule, Long spotId, int dateOrder, int spotOrder) {
         this.schedule = schedule;
         this.spotId = spotId;
-        this.date = date;
-        this.order = order;
+        this.dateOrder = dateOrder;
+        this.spotOrder = spotOrder;
         schedule.getDailyScheduleSpots().add(this);
     }
 
@@ -47,11 +46,11 @@ public class DailyScheduleSpot extends BaseEntity {
         return spotId;
     }
 
-    public int getDate() {
-        return date;
+    public int getDateOrder() {
+        return dateOrder;
     }
 
-    public int getOrder() {
-        return order;
+    public int getSpotOrder() {
+        return spotOrder;
     }
 }

--- a/src/main/java/com/cocodan/triplan/schedule/domain/Memo.java
+++ b/src/main/java/com/cocodan/triplan/schedule/domain/Memo.java
@@ -36,7 +36,7 @@ public class Memo extends BaseEntity {
     private Long memberId;
 
     @Builder
-    public Memo(Schedule schedule, String title, String content, Long memberId) {
+    private Memo(Schedule schedule, String title, String content, Long memberId) {
         this.schedule = schedule;
         this.title = title;
         this.content = content;

--- a/src/main/java/com/cocodan/triplan/schedule/domain/Schedule.java
+++ b/src/main/java/com/cocodan/triplan/schedule/domain/Schedule.java
@@ -57,7 +57,7 @@ public class Schedule extends BaseEntity {
     private List<ScheduleMember> scheduleMembers = new ArrayList<>();
 
     @Builder
-    public Schedule(String title, LocalDate startDate, LocalDate endDate, Long memberId) {
+    private Schedule(String title, LocalDate startDate, LocalDate endDate, Long memberId) {
         this.title = title;
         this.startDate = startDate;
         this.endDate = endDate;

--- a/src/main/java/com/cocodan/triplan/schedule/domain/ScheduleMember.java
+++ b/src/main/java/com/cocodan/triplan/schedule/domain/ScheduleMember.java
@@ -24,7 +24,7 @@ public class ScheduleMember extends BaseEntity {
     private Long memberId;
 
     @Builder
-    public ScheduleMember(Schedule schedule, Long memberId) {
+    private ScheduleMember(Schedule schedule, Long memberId) {
         this.schedule = schedule;
         this.memberId = memberId;
         schedule.getScheduleMembers().add(this);

--- a/src/main/java/com/cocodan/triplan/schedule/domain/ScheduleTheme.java
+++ b/src/main/java/com/cocodan/triplan/schedule/domain/ScheduleTheme.java
@@ -25,7 +25,6 @@ public class ScheduleTheme extends BaseEntity {
     @Column(name = "theme")
     private Theme theme;
 
-    @Builder
     public ScheduleTheme(Schedule schedule, Theme theme) {
         this.schedule = schedule;
         this.theme = theme;

--- a/src/main/java/com/cocodan/triplan/schedule/domain/Voting.java
+++ b/src/main/java/com/cocodan/triplan/schedule/domain/Voting.java
@@ -42,7 +42,7 @@ public class Voting extends BaseEntity {
     private boolean multipleFlag;
 
     @Builder
-    public Voting(String title, Schedule schedule, Long memberId, boolean multipleFlag) {
+    private Voting(String title, Schedule schedule, Long memberId, boolean multipleFlag) {
         this.schedule = schedule;
         this.title = title;
         this.memberId = memberId;

--- a/src/main/java/com/cocodan/triplan/schedule/domain/VotingContent.java
+++ b/src/main/java/com/cocodan/triplan/schedule/domain/VotingContent.java
@@ -32,7 +32,7 @@ public class VotingContent extends BaseEntity {
     private List<VotingContentMember> votingContentMembers = new ArrayList<>();
 
     @Builder
-    public VotingContent(String content, Voting voting) {
+    private VotingContent(String content, Voting voting) {
         this.content = content;
         this.voting = voting;
         this.voting.getVotingContents().add(this);

--- a/src/main/java/com/cocodan/triplan/schedule/domain/VotingContentMember.java
+++ b/src/main/java/com/cocodan/triplan/schedule/domain/VotingContentMember.java
@@ -23,7 +23,7 @@ public class VotingContentMember extends BaseEntity {
     private Long memberId;
 
     @Builder
-    public VotingContentMember(VotingContent votingContent, Long memberId) {
+    private VotingContentMember(VotingContent votingContent, Long memberId) {
         this.votingContent = votingContent;
         this.memberId = memberId;
     }

--- a/src/main/java/com/cocodan/triplan/schedule/domain/vo/Theme.java
+++ b/src/main/java/com/cocodan/triplan/schedule/domain/vo/Theme.java
@@ -8,8 +8,8 @@ public enum Theme {
     ACTIVITY("ACTIVITY"),
     FOOD("FOOD"),
     ART("ART"),
-    ARCHITECT("ARCHITECT"),
     NATURE("NATURE"),
+    HISTORY("HISTORY"),
     ALL("ALL"); // 검색 전용
 
     private String value;

--- a/src/main/java/com/cocodan/triplan/schedule/dto/request/DailyScheduleSpotCreationRequest.java
+++ b/src/main/java/com/cocodan/triplan/schedule/dto/request/DailyScheduleSpotCreationRequest.java
@@ -32,8 +32,8 @@ public class DailyScheduleSpotCreationRequest {
     @NotNull
     private Position position;
 
-    private int date;
+    private int dateOrder;
 
-    private int order;
+    private int spotOrder;
 
 }

--- a/src/main/java/com/cocodan/triplan/schedule/dto/response/ChecklistResponse.java
+++ b/src/main/java/com/cocodan/triplan/schedule/dto/response/ChecklistResponse.java
@@ -1,27 +1,21 @@
 package com.cocodan.triplan.schedule.dto.response;
 
 import com.cocodan.triplan.schedule.domain.Checklist;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
+@Builder(access = AccessLevel.PRIVATE)
 public class ChecklistResponse {
 
-    private Long id;
+    private final Long id;
 
-    private String content;
+    private final String content;
 
-    private boolean checked;
+    private final boolean checked;
 
-    private int day;
-
-    @Builder
-    private ChecklistResponse(Long id, String content, boolean checked, int day) {
-        this.id = id;
-        this.content = content;
-        this.checked = checked;
-        this.day = day;
-    }
+    private final int day;
 
     public static ChecklistResponse from(Checklist checklist) {
         return ChecklistResponse.builder()

--- a/src/main/java/com/cocodan/triplan/schedule/dto/response/DailyScheduleSpotResponse.java
+++ b/src/main/java/com/cocodan/triplan/schedule/dto/response/DailyScheduleSpotResponse.java
@@ -2,12 +2,8 @@ package com.cocodan.triplan.schedule.dto.response;
 
 import com.cocodan.triplan.schedule.domain.DailyScheduleSpot;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-
-import java.time.LocalDate;
-import java.util.Objects;
 
 @Getter
 @Builder(access = AccessLevel.PRIVATE)
@@ -15,15 +11,15 @@ public class DailyScheduleSpotResponse {
 
     private final Long spotId;
 
-    private final int date;
+    private final int dateOrder;
 
-    private final int order;
+    private final int spotOrder;
 
     public static DailyScheduleSpotResponse from(DailyScheduleSpot dailyScheduleSpot) {
         return DailyScheduleSpotResponse.builder()
                 .spotId(dailyScheduleSpot.getSpotId())
-                .date(dailyScheduleSpot.getDate())
-                .order(dailyScheduleSpot.getOrder())
+                .dateOrder(dailyScheduleSpot.getDateOrder())
+                .spotOrder(dailyScheduleSpot.getSpotOrder())
                 .build();
     }
 
@@ -32,14 +28,14 @@ public class DailyScheduleSpotResponse {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         DailyScheduleSpotResponse that = (DailyScheduleSpotResponse) o;
-        return spotId.equals(that.spotId) && date == that.date && order == that.order;
+        return spotId.equals(that.spotId) && dateOrder == that.dateOrder && spotOrder == that.spotOrder;
     }
 
     @Override
     public int hashCode() {
         int result = spotId.hashCode();
-        result = 31 * result + date;
-        result = 31 * result + order;
+        result = 31 * result + dateOrder;
+        result = 31 * result + spotOrder;
         return result;
     }
 }

--- a/src/main/java/com/cocodan/triplan/schedule/dto/response/DailyScheduleSpotResponse.java
+++ b/src/main/java/com/cocodan/triplan/schedule/dto/response/DailyScheduleSpotResponse.java
@@ -1,6 +1,7 @@
 package com.cocodan.triplan.schedule.dto.response;
 
 import com.cocodan.triplan.schedule.domain.DailyScheduleSpot;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -9,20 +10,14 @@ import java.time.LocalDate;
 import java.util.Objects;
 
 @Getter
+@Builder(access = AccessLevel.PRIVATE)
 public class DailyScheduleSpotResponse {
 
-    private Long spotId;
+    private final Long spotId;
 
-    private int date;
+    private final int date;
 
-    private int order;
-
-    @Builder
-    private DailyScheduleSpotResponse(Long spotId, int date, int order) {
-        this.spotId = spotId;
-        this.date = date;
-        this.order = order;
-    }
+    private final int order;
 
     public static DailyScheduleSpotResponse from(DailyScheduleSpot dailyScheduleSpot) {
         return DailyScheduleSpotResponse.builder()
@@ -38,5 +33,13 @@ public class DailyScheduleSpotResponse {
         if (o == null || getClass() != o.getClass()) return false;
         DailyScheduleSpotResponse that = (DailyScheduleSpotResponse) o;
         return spotId.equals(that.spotId) && date == that.date && order == that.order;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = spotId.hashCode();
+        result = 31 * result + date;
+        result = 31 * result + order;
+        return result;
     }
 }

--- a/src/main/java/com/cocodan/triplan/schedule/dto/response/IdResponse.java
+++ b/src/main/java/com/cocodan/triplan/schedule/dto/response/IdResponse.java
@@ -7,5 +7,5 @@ import lombok.Getter;
 @AllArgsConstructor
 public class IdResponse {
 
-    private Long id;
+    private final Long id;
 }

--- a/src/main/java/com/cocodan/triplan/schedule/dto/response/MemoDetailResponse.java
+++ b/src/main/java/com/cocodan/triplan/schedule/dto/response/MemoDetailResponse.java
@@ -3,10 +3,12 @@ package com.cocodan.triplan.schedule.dto.response;
 import com.cocodan.triplan.member.domain.Member;
 import com.cocodan.triplan.member.dto.response.MemberSimpleResponse;
 import com.cocodan.triplan.schedule.domain.Memo;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
+@Builder(access = AccessLevel.PRIVATE)
 public class MemoDetailResponse {
 
     private final Long id;
@@ -16,14 +18,6 @@ public class MemoDetailResponse {
     private final String content;
 
     private final MemberSimpleResponse memberSimpleResponse;
-
-    @Builder
-    private MemoDetailResponse(Long id, String title, String content, MemberSimpleResponse memberSimpleResponse) {
-        this.id = id;
-        this.title = title;
-        this.content = content;
-        this.memberSimpleResponse = memberSimpleResponse;
-    }
 
     public static MemoDetailResponse of(Memo memo, Member member) {
         return MemoDetailResponse.builder()

--- a/src/main/java/com/cocodan/triplan/schedule/dto/response/MemoSimpleResponse.java
+++ b/src/main/java/com/cocodan/triplan/schedule/dto/response/MemoSimpleResponse.java
@@ -1,10 +1,12 @@
 package com.cocodan.triplan.schedule.dto.response;
 
 import com.cocodan.triplan.schedule.domain.Memo;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
+@Builder(access = AccessLevel.PRIVATE)
 public class MemoSimpleResponse {
 
     private final Long id;
@@ -12,13 +14,6 @@ public class MemoSimpleResponse {
     private final String title;
 
     private final String content;
-
-    @Builder
-    private MemoSimpleResponse(Long id, String title, String content) {
-        this.id = id;
-        this.title = title;
-        this.content = content;
-    }
 
     public static MemoSimpleResponse from(Memo memo) {
         return MemoSimpleResponse.builder()

--- a/src/main/java/com/cocodan/triplan/schedule/dto/response/ScheduleDetailResponse.java
+++ b/src/main/java/com/cocodan/triplan/schedule/dto/response/ScheduleDetailResponse.java
@@ -43,9 +43,9 @@ public class ScheduleDetailResponse {
     }
 
     private static int sortByDateAndOrder(DailyScheduleSpot o1, DailyScheduleSpot o2) {
-        int compareResult = o1.getDate() - o2.getDate();
+        int compareResult = o1.getDateOrder() - o2.getDateOrder();
         if (compareResult == 0) {
-            return o1.getOrder() - o2.getOrder();
+            return o1.getSpotOrder() - o2.getSpotOrder();
         }
 
         return compareResult;

--- a/src/main/java/com/cocodan/triplan/schedule/dto/response/ScheduleDetailResponse.java
+++ b/src/main/java/com/cocodan/triplan/schedule/dto/response/ScheduleDetailResponse.java
@@ -5,6 +5,7 @@ import com.cocodan.triplan.member.dto.response.MemberSimpleResponse;
 import com.cocodan.triplan.schedule.domain.DailyScheduleSpot;
 import com.cocodan.triplan.schedule.domain.Schedule;
 import com.cocodan.triplan.spot.domain.Spot;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -12,6 +13,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 @Getter
+@Builder(access = AccessLevel.PRIVATE)
 public class ScheduleDetailResponse {
 
     private final Long id;
@@ -21,14 +23,6 @@ public class ScheduleDetailResponse {
     private final List<ScheduleSpotResponse> spotResponseList;
 
     private final List<MemberSimpleResponse> memberSimpleResponses;
-
-    @Builder
-    private ScheduleDetailResponse(Long id, ScheduleSimpleResponse scheduleSimpleResponse, List<ScheduleSpotResponse> spotResponseList, List<MemberSimpleResponse> memberSimpleResponses) {
-        this.id = id;
-        this.scheduleSimpleResponse = scheduleSimpleResponse;
-        this.spotResponseList = spotResponseList;
-        this.memberSimpleResponses = memberSimpleResponses;
-    }
 
     public static ScheduleDetailResponse of(Schedule schedule, List<Spot> spotList, List<Member> members) {
         return ScheduleDetailResponse.builder()

--- a/src/main/java/com/cocodan/triplan/schedule/dto/response/ScheduleSimpleResponse.java
+++ b/src/main/java/com/cocodan/triplan/schedule/dto/response/ScheduleSimpleResponse.java
@@ -3,6 +3,7 @@ package com.cocodan.triplan.schedule.dto.response;
 import com.cocodan.triplan.schedule.domain.Schedule;
 import com.cocodan.triplan.schedule.domain.ScheduleTheme;
 import com.cocodan.triplan.schedule.domain.vo.Theme;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -11,6 +12,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 @Getter
+@Builder(access = AccessLevel.PRIVATE)
 public class ScheduleSimpleResponse {
 
     private final Long id;
@@ -22,15 +24,6 @@ public class ScheduleSimpleResponse {
     private final LocalDate endDate;
 
     private final List<Theme> themes;
-
-    @Builder
-    private ScheduleSimpleResponse(Long id, String title, LocalDate startDate, LocalDate endDate, List<Theme> themes) {
-        this.id = id;
-        this.title = title;
-        this.startDate = startDate;
-        this.endDate = endDate;
-        this.themes = themes;
-    }
 
     public static ScheduleSimpleResponse from(Schedule schedule) {
         return ScheduleSimpleResponse.builder()

--- a/src/main/java/com/cocodan/triplan/schedule/dto/response/ScheduleSpotResponse.java
+++ b/src/main/java/com/cocodan/triplan/schedule/dto/response/ScheduleSpotResponse.java
@@ -1,38 +1,45 @@
 package com.cocodan.triplan.schedule.dto.response;
 
 import com.cocodan.triplan.schedule.domain.DailyScheduleSpot;
+import com.cocodan.triplan.schedule.dto.request.Position;
 import com.cocodan.triplan.spot.domain.Spot;
-import com.cocodan.triplan.spot.dto.response.SpotResponse;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 
-import java.time.LocalDate;
-
 @Getter
+@Builder(access = AccessLevel.PRIVATE)
 public class ScheduleSpotResponse {
 
     private final Long id;
-
-    private final SpotResponse spotResponse;
 
     private final int date;
 
     private final int order;
 
-    @Builder
-    private ScheduleSpotResponse(Long id, SpotResponse spotResponse, int date, int order) {
-        this.id = id;
-        this.spotResponse = spotResponse;
-        this.date = date;
-        this.order = order;
-    }
+    private final Long spotId;
+
+    private final String placeName;
+
+    private final String addressName;
+
+    private final String roadAddressName;
+
+    private final String phone;
+
+    private final Position position;
 
     public static ScheduleSpotResponse of(Spot spot, DailyScheduleSpot dailyScheduleSpot) {
         return ScheduleSpotResponse.builder()
                 .id(dailyScheduleSpot.getId())
                 .date(dailyScheduleSpot.getDate())
                 .order(dailyScheduleSpot.getOrder())
-                .spotResponse(SpotResponse.from(spot))
+                .spotId(spot.getId())
+                .placeName(spot.getPlaceName())
+                .addressName(spot.getAddressName())
+                .roadAddressName(spot.getRoadAddressName())
+                .phone(spot.getPhone())
+                .position(new Position(spot.getLatitude(), spot.getLongitude()))
                 .build();
     }
 }

--- a/src/main/java/com/cocodan/triplan/schedule/dto/response/ScheduleSpotResponse.java
+++ b/src/main/java/com/cocodan/triplan/schedule/dto/response/ScheduleSpotResponse.java
@@ -32,8 +32,8 @@ public class ScheduleSpotResponse {
     public static ScheduleSpotResponse of(Spot spot, DailyScheduleSpot dailyScheduleSpot) {
         return ScheduleSpotResponse.builder()
                 .id(dailyScheduleSpot.getId())
-                .date(dailyScheduleSpot.getDate())
-                .order(dailyScheduleSpot.getOrder())
+                .date(dailyScheduleSpot.getDateOrder())
+                .order(dailyScheduleSpot.getSpotOrder())
                 .spotId(spot.getId())
                 .placeName(spot.getPlaceName())
                 .addressName(spot.getAddressName())

--- a/src/main/java/com/cocodan/triplan/schedule/dto/response/VotingContentResponse.java
+++ b/src/main/java/com/cocodan/triplan/schedule/dto/response/VotingContentResponse.java
@@ -1,10 +1,12 @@
 package com.cocodan.triplan.schedule.dto.response;
 
 import com.cocodan.triplan.schedule.domain.VotingContent;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
+@Builder(access = AccessLevel.PRIVATE)
 public class VotingContentResponse {
 
     private final Long id;
@@ -14,14 +16,6 @@ public class VotingContentResponse {
     private final int numOfParticipants;
 
     private final boolean participantFlag;
-
-    @Builder
-    private VotingContentResponse(Long id, String content, int numOfParticipants, boolean participantFlag) {
-        this.id = id;
-        this.content = content;
-        this.numOfParticipants = numOfParticipants;
-        this.participantFlag = participantFlag;
-    }
 
     public static VotingContentResponse convertVotingContentResponse(VotingContent votingContent, Long memberId) {
         return VotingContentResponse.builder()

--- a/src/main/java/com/cocodan/triplan/schedule/dto/response/VotingDetailResponse.java
+++ b/src/main/java/com/cocodan/triplan/schedule/dto/response/VotingDetailResponse.java
@@ -4,6 +4,7 @@ import com.cocodan.triplan.member.domain.Member;
 import com.cocodan.triplan.member.domain.vo.GenderType;
 import com.cocodan.triplan.member.dto.response.MemberSimpleResponse;
 import com.cocodan.triplan.schedule.domain.Voting;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -11,6 +12,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 @Getter
+@Builder(access = AccessLevel.PRIVATE)
 public class VotingDetailResponse {
 
     private final Long id;
@@ -24,16 +26,6 @@ public class VotingDetailResponse {
     private final MemberSimpleResponse memberSimpleResponse;
 
     private final boolean multipleFlag;
-
-    @Builder
-    private VotingDetailResponse(Long id, String title, int numOfTotalParticipants, List<VotingContentResponse> votingContentResponses, MemberSimpleResponse memberSimpleResponse, boolean multipleFlag) {
-        this.id = id;
-        this.title = title;
-        this.numOfTotalParticipants = numOfTotalParticipants;
-        this.votingContentResponses = votingContentResponses;
-        this.memberSimpleResponse = memberSimpleResponse;
-        this.multipleFlag = multipleFlag;
-    }
 
     public static VotingDetailResponse of(Voting voting, Member member, Long memberId) {
         int numOfTotalParticipants = voting.getNumOfTotalParticipants();

--- a/src/main/java/com/cocodan/triplan/schedule/dto/response/VotingSimpleResponse.java
+++ b/src/main/java/com/cocodan/triplan/schedule/dto/response/VotingSimpleResponse.java
@@ -1,10 +1,12 @@
 package com.cocodan.triplan.schedule.dto.response;
 
 import com.cocodan.triplan.schedule.domain.Voting;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
+@Builder(access = AccessLevel.PRIVATE)
 public class VotingSimpleResponse {
 
     private final Long id;
@@ -12,13 +14,6 @@ public class VotingSimpleResponse {
     private final String title;
 
     private final int memberCount;
-
-    @Builder
-    private VotingSimpleResponse(Long id, String title, int memberCount) {
-        this.id = id;
-        this.title = title;
-        this.memberCount = memberCount;
-    }
 
     public static VotingSimpleResponse from(Voting voting) {
         return VotingSimpleResponse.builder()

--- a/src/main/java/com/cocodan/triplan/schedule/service/ScheduleService.java
+++ b/src/main/java/com/cocodan/triplan/schedule/service/ScheduleService.java
@@ -91,8 +91,8 @@ public class ScheduleService {
     private void createDailyScheduleSpot(Schedule schedule, DailyScheduleSpotCreationRequest dailyScheduleSpotCreationRequest) {
         DailyScheduleSpot.builder()
                 .spotId(dailyScheduleSpotCreationRequest.getSpotId())
-                .date(dailyScheduleSpotCreationRequest.getDate())
-                .order(dailyScheduleSpotCreationRequest.getOrder())
+                .dateOrder(dailyScheduleSpotCreationRequest.getDateOrder())
+                .spotOrder(dailyScheduleSpotCreationRequest.getSpotOrder())
                 .schedule(schedule)
                 .build();
     }

--- a/src/main/java/com/cocodan/triplan/spot/dto/response/SpotResponse.java
+++ b/src/main/java/com/cocodan/triplan/spot/dto/response/SpotResponse.java
@@ -1,12 +1,14 @@
 package com.cocodan.triplan.spot.dto.response;
 
 import com.cocodan.triplan.schedule.dto.request.Position;
+import com.cocodan.triplan.schedule.dto.response.ScheduleSpotResponse;
 import com.cocodan.triplan.spot.domain.Spot;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-@Builder
+@Builder(access = AccessLevel.PRIVATE)
 public class SpotResponse {
 
     private Long id;

--- a/src/test/java/com/cocodan/triplan/schedule/service/ScheduleServiceTest.java
+++ b/src/test/java/com/cocodan/triplan/schedule/service/ScheduleServiceTest.java
@@ -145,8 +145,7 @@ class ScheduleServiceTest {
         assertThat(memberNicknames).containsExactly("henry");
 
         List<Long> spotIds = response.getSpotResponseList().stream()
-                .map(ScheduleSpotResponse::getSpotResponse)
-                .map(SpotResponse::getId)
+                .map(ScheduleSpotResponse::getSpotId)
                 .collect(Collectors.toList());
 
         assertThat(spotIds).containsExactly(11L, 21L, 31L, 41L, 51L, 61L, 71L, 81L);


### PR DESCRIPTION
모든 Dto private Builder로 변경 및 final 키워드, 일정 응답 형식 프론트에 맞게 수정
엔티티의 생성자도 빌더를 쓸 경우 private로 변경, 일정 조회 응답 형식 재수정