### PR TITLE
[TP-98] Feature : 회원 리펙토링 및 수정 사항 적용

### DIFF
--- a/src/main/java/com/cocodan/triplan/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/cocodan/triplan/exception/GlobalExceptionHandler.java
@@ -10,6 +10,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.validation.FieldError;
 import org.springframework.validation.ObjectError;
@@ -105,7 +106,23 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler
     public ResponseEntity<ExceptionResponse> handleInvalidLogin(BadCredentialsException exception) {
-        log.warn("Invalid login data : {}", exception.getMessage());
+        log.warn("Invalid token data : {}", exception.getMessage());
+        loggingWarningStackTrace(exception);
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ExceptionResponse.from(exception.getMessage()));
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<ExceptionResponse> handleInvalidLogin(IllegalArgumentException exception) {
+        log.warn("Invalid login password check : {}", exception.getMessage());
+        loggingWarningStackTrace(exception);
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ExceptionResponse.from(exception.getMessage()));
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<ExceptionResponse> handleInvalidLogin(UsernameNotFoundException exception) {
+        log.warn("Invalid login email : {}", exception.getMessage());
         loggingWarningStackTrace(exception);
 
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ExceptionResponse.from(exception.getMessage()));

--- a/src/main/java/com/cocodan/triplan/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/cocodan/triplan/jwt/JwtAuthenticationFilter.java
@@ -1,11 +1,10 @@
 package com.cocodan.triplan.jwt;
 
+import com.auth0.jwt.exceptions.TokenExpiredException;
 import com.cocodan.triplan.config.JwtAuthenticationSuccessHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.log.LogMessage;
-import org.springframework.http.HttpHeaders;
-import org.springframework.security.authentication.event.InteractiveAuthenticationSuccessEvent;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -18,7 +17,6 @@ import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
-import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -70,7 +68,13 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
                         successfulAuthentication(request, response, chain, authentication);
                     }
                 } catch (Exception e) {
+                    log.warn("Exception type: {}", e.getClass().getSimpleName());
                     log.warn("Jwt processing failed: {}", e.getMessage());
+                    if (e.getClass() == TokenExpiredException.class)
+                    {
+                        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                        throw new TokenExpiredException("Login Token has expired!");
+                    }
                 }
             }
         } else {

--- a/src/main/java/com/cocodan/triplan/member/controller/MemberController.java
+++ b/src/main/java/com/cocodan/triplan/member/controller/MemberController.java
@@ -7,17 +7,10 @@ import com.cocodan.triplan.member.domain.Member;
 import com.cocodan.triplan.member.dto.request.MemberCreateRequest;
 import com.cocodan.triplan.member.dto.request.MemberLoginRequest;
 import com.cocodan.triplan.member.dto.request.MemberUpdateRequest;
-import com.cocodan.triplan.member.dto.response.MemberCreateResponse;
-import com.cocodan.triplan.member.dto.response.MemberDeleteResponse;
-import com.cocodan.triplan.member.dto.response.MemberGetOneResponse;
-import com.cocodan.triplan.member.dto.response.MemberSimpleResponse;
-import com.cocodan.triplan.member.dto.response.MemberUpdateResponse;
+import com.cocodan.triplan.member.dto.response.*;
 import com.cocodan.triplan.member.service.MemberService;
 import io.swagger.annotations.Api;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.core.Authentication;
@@ -27,7 +20,6 @@ import io.swagger.annotations.ApiOperation;
 
 import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
-import java.util.Optional;
 import java.util.List;
 
 @Api(tags = "Member")
@@ -42,8 +34,8 @@ public class MemberController {
 
     @ApiOperation("회원(Member) 신규 추가, 성공시 생성된 Member ID 반환")
     @PostMapping("/register")
-    public ResponseEntity<Void> signUp(@Valid @RequestBody MemberCreateRequest request) {
-        memberService.validCreate(
+    public ResponseEntity<MemberCreateResponse> signUp(@Valid @RequestBody MemberCreateRequest request) {
+        MemberCreateResponse response = memberService.validCreate(
                 request.getEmail(),
                 request.getName(),
                 request.getBirth(),
@@ -54,7 +46,7 @@ public class MemberController {
                 GROUP_ID
         );
 
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok(response);
     }
 
     @ApiOperation("회원(Member) 단건 조회, 성공시 Member 정보 반환")
@@ -71,7 +63,7 @@ public class MemberController {
     public ResponseEntity<List<MemberSimpleResponse>> findMemberByNickname(@RequestParam String nickname) {
         List<MemberSimpleResponse> responses = memberService.findMemberByNickname(nickname);
 
-        return new ResponseEntity<>(responses, HttpStatus.OK);
+        return ResponseEntity.ok(responses);
     }
 
     @ApiOperation("회원(Member) 단건 수정, 성공시 수정된 Member 정보 반환")
@@ -96,14 +88,16 @@ public class MemberController {
     }
 
     @PostMapping(path = "/login")
-    public ResponseEntity<Void> login(@RequestBody MemberLoginRequest request, HttpServletResponse httpServletResponse) {
+    public ResponseEntity<MemberLoginResponse> login(@RequestBody MemberLoginRequest request, HttpServletResponse httpServletResponse) {
         JwtAuthenticationToken authToken = new JwtAuthenticationToken(request.getEmail(), request.getPassword());
         Authentication resultToken = authenticationManager.authenticate(authToken);
         JwtAuthentication authentication = (JwtAuthentication) resultToken.getPrincipal();
 
         httpServletResponse.setHeader("token", authentication.getToken());
 
-        return ResponseEntity.ok().build();
+        MemberLoginResponse response = new MemberLoginResponse(authentication.getToken(), authentication.getId());
+
+        return ResponseEntity.ok(response);
     }
 
     @ApiOperation("내 프로필 조회")

--- a/src/main/java/com/cocodan/triplan/member/domain/Member.java
+++ b/src/main/java/com/cocodan/triplan/member/domain/Member.java
@@ -113,7 +113,7 @@ public class Member extends BaseEntity {
 
     public void checkPassword(PasswordEncoder passwordEncoder, String credentials) {
         if (!passwordEncoder.matches(credentials, password))
-            throw new IllegalArgumentException("Bad credential");
+            throw new IllegalArgumentException("Invalid user's password username");
     }
 
     public int getAge() {

--- a/src/main/java/com/cocodan/triplan/member/domain/Member.java
+++ b/src/main/java/com/cocodan/triplan/member/domain/Member.java
@@ -83,6 +83,10 @@ public class Member extends BaseEntity {
         return id;
     }
 
+    public String getPassword() {
+        return password;
+    }
+
     public String getEmail() {
         return email;
     }
@@ -109,11 +113,6 @@ public class Member extends BaseEntity {
 
     public Group getGroup() {
         return group;
-    }
-
-    public void checkPassword(PasswordEncoder passwordEncoder, String credentials) {
-        if (!passwordEncoder.matches(credentials, password))
-            throw new IllegalArgumentException("Invalid user's password username");
     }
 
     public int getAge() {

--- a/src/main/java/com/cocodan/triplan/member/domain/vo/GenderType.java
+++ b/src/main/java/com/cocodan/triplan/member/domain/vo/GenderType.java
@@ -4,8 +4,7 @@ import java.util.Arrays;
 
 public enum GenderType {
     MALE("MALE"),
-    FEMALE("FEMALE"),
-    DEFAULT("미입력");
+    FEMALE("FEMALE");
 
     private final String typeStr;
 

--- a/src/main/java/com/cocodan/triplan/member/domain/vo/GenderType.java
+++ b/src/main/java/com/cocodan/triplan/member/domain/vo/GenderType.java
@@ -3,8 +3,8 @@ package com.cocodan.triplan.member.domain.vo;
 import java.util.Arrays;
 
 public enum GenderType {
-    MALE("남성"),
-    FEMALE("여성"),
+    MALE("MALE"),
+    FEMALE("FEMALE"),
     DEFAULT("미입력");
 
     private final String typeStr;

--- a/src/main/java/com/cocodan/triplan/member/dto/request/MemberCreateRequest.java
+++ b/src/main/java/com/cocodan/triplan/member/dto/request/MemberCreateRequest.java
@@ -1,6 +1,6 @@
 package com.cocodan.triplan.member.dto.request;
 
-import com.cocodan.triplan.schedule.domain.Checklist;
+import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -31,6 +31,7 @@ public class MemberCreateRequest {
     @Pattern(regexp="^\\d{4}-\\d{2}-\\d{2}$", message="'yyyy-mm-dd'형식으로 작성해주세요")
     private String birth;
 
+    @ApiModelProperty(required = true, example = "string(MALE or FEMALE)")
     @Pattern(regexp="^[ㄱ-ㅎ|가-힣|a-z|A-Z]{1,10}$", message="성별은 1~10자이어야 합니다")
     private String gender;
 

--- a/src/main/java/com/cocodan/triplan/member/service/MemberService.java
+++ b/src/main/java/com/cocodan/triplan/member/service/MemberService.java
@@ -5,6 +5,7 @@ import com.cocodan.triplan.member.dto.response.*;
 import com.cocodan.triplan.util.MemberConverter;
 import com.cocodan.triplan.member.domain.Member;
 import com.cocodan.triplan.member.repository.MemberRepository;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -20,6 +21,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 
 @Service
+@Slf4j
 public class MemberService {
 
     private final PasswordEncoder passwordEncoder;
@@ -98,7 +100,11 @@ public class MemberService {
         Member member = memberRepository.findByLoginId(email)
                 .orElseThrow(() -> new UsernameNotFoundException("Could not found user for " + email));
 
-        member.checkPassword(passwordEncoder, credentials);
+        if (!passwordEncoder.matches(credentials, member.getPassword()))
+        {
+            log.warn("Invalid password. user email : " + email);
+            throw new IllegalArgumentException("Invalid password.");
+        }
 
         return member;
     }

--- a/src/test/java/com/cocodan/triplan/schedule/service/ScheduleServiceTest.java
+++ b/src/test/java/com/cocodan/triplan/schedule/service/ScheduleServiceTest.java
@@ -59,7 +59,7 @@ class ScheduleServiceTest {
                 "ffff@naver.com",
                 "taehyun",
                 "1994-12-16",
-                "남성",
+                "MALE",
                 "henry",
                 "",
                 "asdf123",


### PR DESCRIPTION
- 로그인 이메일/비밀번호 불일치로 실패 시 응답 추가
- 회원 성별 데이터 (남성/여성) >> (MALE, FEMALE)로 변경
- swagger 성별 enum 안내 메세지 추가
- 로그인 토큰 만료 시 401 응답 코드 전송하도록 변경