### PR TITLE
[TP-117] 게시글 삭제 불가 및 좋아요 수 음수 발생 문제 대응

### DIFF
--- a/src/main/java/com/cocodan/triplan/post/schedule/controller/SchedulePostController.java
+++ b/src/main/java/com/cocodan/triplan/post/schedule/controller/SchedulePostController.java
@@ -175,6 +175,9 @@ public class SchedulePostController {
         // TODO: 2021.12.15 Teru - 댓글에 대댓글이 작성되어 있는 상태에서 댓글이 삭제되면 어떻게 할 것인지 고민
         // 방법 1. 삭제된 댓글은 공란(삭제됨 표시)으로 두고, 아래 대댓글은 표시한다.
         // 방법 2. 삭제된 댓글에 있던 대댓글도 모두 삭제한다.
+        // -> Henry 등의 의견으로 1이 좋을 것이라 생각되나, 삭제 관련 기능에서 오류가 발생합니다. (코멘트가 삭제되기 위해서는 해당 comment의 ID를 FK로 가지는 모든 대댓글이 먼저 삭제되어야 함)
+        // 그래서 일단 방법 2 쪽으로 먼저 구현합니다. (게시글 삭제 -> 대댓글, 댓글, 좋아요 순으로 선행 삭제 / 댓글 삭제 -> 대댓글, 댓글 순으로 삭제)
+        // -> TODO: 추후 연관관계 관련 문제 해결하고 방법 1로 교체
         schedulePostService.deleteSchedulePostComment(schedulePostId, commentId, authentication.getId());
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/com/cocodan/triplan/post/schedule/controller/SchedulePostController.java
+++ b/src/main/java/com/cocodan/triplan/post/schedule/controller/SchedulePostController.java
@@ -137,7 +137,7 @@ public class SchedulePostController {
             @Valid @RequestBody SchedulePostLikeRequest request,
             @AuthenticationPrincipal JwtAuthentication authentication
     ) {
-        Long likeCount = schedulePostService.toggleSchedulePostLiked(authentication.getId(), request);
+        Long likeCount = schedulePostService.toggleSchedulePostLiked(authentication.getId(), schedulePostId, request);
         return ResponseEntity.ok(new SchedulePostLikeResponse(likeCount));
     }
 

--- a/src/main/java/com/cocodan/triplan/post/schedule/domain/SchedulePost.java
+++ b/src/main/java/com/cocodan/triplan/post/schedule/domain/SchedulePost.java
@@ -21,6 +21,7 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
+import javax.validation.constraints.PositiveOrZero;
 
 @Entity
 @Getter
@@ -54,9 +55,11 @@ public class SchedulePost extends BaseEntity {
     @Length(min = SCHEDULE_POST_CONTENT_MIN_LENGTH, max = SCHEDULE_POST_CONTENT_MAX_LENGTH)
     private String content;
 
+    @PositiveOrZero
     @Column(name = "views", nullable = false)
     private long views;
 
+    @PositiveOrZero
     @Column(name = "liked", nullable = false)
     private long liked;
 
@@ -100,6 +103,6 @@ public class SchedulePost extends BaseEntity {
     }
 
     public long decreaseLiked() {
-        return --liked;
+        return liked <= 0 ? 0 : --liked;
     }
 }

--- a/src/main/java/com/cocodan/triplan/post/schedule/dto/request/SchedulePostLikeRequest.java
+++ b/src/main/java/com/cocodan/triplan/post/schedule/dto/request/SchedulePostLikeRequest.java
@@ -12,8 +12,5 @@ import javax.validation.constraints.NotNull;
 public class SchedulePostLikeRequest {
 
     @NotNull
-    private Long schedulePostId;
-
-    @NotNull
     private Boolean flag;
 }

--- a/src/main/java/com/cocodan/triplan/post/schedule/repository/SchedulePostLikeRepository.java
+++ b/src/main/java/com/cocodan/triplan/post/schedule/repository/SchedulePostLikeRepository.java
@@ -2,6 +2,7 @@ package com.cocodan.triplan.post.schedule.repository;
 
 import com.cocodan.triplan.post.schedule.domain.Like;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
@@ -13,4 +14,8 @@ public interface SchedulePostLikeRepository extends JpaRepository<Like, Long> {
     Optional<Like> findByMemberIdAndSchedulePostId(Long memberId, Long schedulePostId);
 
     List<Like> findAllByMemberId(Long memberId);
+
+    @Modifying
+    @Query("DELETE FROM Like l where l.schedulePost.id = :schedulePostId")
+    void deleteAllBySchedulePostId(Long schedulePostId);
 }

--- a/src/main/java/com/cocodan/triplan/post/schedule/repository/SchedulePostNestedCommentRepository.java
+++ b/src/main/java/com/cocodan/triplan/post/schedule/repository/SchedulePostNestedCommentRepository.java
@@ -2,6 +2,7 @@ package com.cocodan.triplan.post.schedule.repository;
 
 import com.cocodan.triplan.post.schedule.domain.SchedulePostNestedComment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
@@ -9,4 +10,8 @@ import java.util.List;
 public interface SchedulePostNestedCommentRepository extends JpaRepository<SchedulePostNestedComment, Long> {
     @Query("select nc from SchedulePostNestedComment nc where nc.parentComment.id = :commentId")
     List<SchedulePostNestedComment> findAllByCommentId(Long commentId);
+
+    @Modifying
+    @Query("DELETE from SchedulePostNestedComment nc where nc.parentComment.id = :commentId")
+    void deleteAllByCommentId(Long commentId);
 }

--- a/src/main/java/com/cocodan/triplan/post/schedule/service/SchedulePostService.java
+++ b/src/main/java/com/cocodan/triplan/post/schedule/service/SchedulePostService.java
@@ -133,9 +133,7 @@ public class SchedulePostService {
     }
 
     @Transactional
-    public Long toggleSchedulePostLiked(Long memberId, SchedulePostLikeRequest request) {
-        // TODO: 2021.12.13 Teru - 좋아요 수에 대한 동시성 문제를 어떻게하면 더 잘 해결할 수 있을지 고민...
-        Long schedulePostId = request.getSchedulePostId();
+    public Long toggleSchedulePostLiked(Long memberId, Long schedulePostId, SchedulePostLikeRequest request) {
         Optional<Like> likeData = getLike(memberId, schedulePostId);
         SchedulePost post = getSchedulePostForLikeUpdate(schedulePostId);
 
@@ -143,16 +141,13 @@ public class SchedulePostService {
             Member member = getMember(memberId);
             Like like = new Like(member, post);
             schedulePostLikeRepository.save(like);
-            return post.increaseLiked();
-        }
-
-        if (likeData.isPresent() && !request.getFlag()) {
+            post.increaseLiked();
+        } else if (likeData.isPresent() && !request.getFlag()) {
             schedulePostLikeRepository.delete(likeData.get());
-            return post.decreaseLiked();
+            post.decreaseLiked();
         }
 
-        // Invalid Like toggle
-        return post.getLiked();
+        return schedulePostRepository.save(post).getId();
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/cocodan/triplan/post/schedule/service/SchedulePostService.java
+++ b/src/main/java/com/cocodan/triplan/post/schedule/service/SchedulePostService.java
@@ -112,7 +112,18 @@ public class SchedulePostService {
 
     @Transactional
     public void deleteSchedulePost(Long memberId, Long schedulePostId) {
+        nullCheck(memberId, schedulePostId);
         SchedulePost schedulePost = validateAuthorities(memberId, schedulePostId);
+
+        // 대댓글 -> 댓글 -> 좋아요 순으로 선행 삭제
+        List<SchedulePostComment> comments = getCommentsOf(schedulePost);
+
+        for (SchedulePostComment comment : comments) {
+            schedulePostNestedCommentRepository.deleteAllByCommentId(comment.getId());
+            schedulePostCommentRepository.delete(comment);
+        }
+        schedulePostLikeRepository.deleteAllBySchedulePostId(schedulePostId);
+
         schedulePostRepository.delete(schedulePost);
     }
 
@@ -147,7 +158,8 @@ public class SchedulePostService {
             post.decreaseLiked();
         }
 
-        return schedulePostRepository.save(post).getId();
+        schedulePostRepository.save(post);
+        return post.getLiked();
     }
 
     @Transactional(readOnly = true)
@@ -198,6 +210,8 @@ public class SchedulePostService {
     @Transactional
     public void deleteSchedulePostComment(Long schedulePostId, Long commentId, Long memberId) {
         validateCommentOwnership(schedulePostId, commentId, memberId);
+        // 대댓글 선행 삭제
+        schedulePostNestedCommentRepository.deleteAllByCommentId(commentId);
         schedulePostCommentRepository.deleteById(commentId);
     }
 

--- a/src/test/java/com/cocodan/triplan/post/schedule/service/SchedulePostServiceTest.java
+++ b/src/test/java/com/cocodan/triplan/post/schedule/service/SchedulePostServiceTest.java
@@ -349,11 +349,11 @@ class SchedulePostServiceTest {
         long beforeLiked = post.getLiked();
 
         // 좋아요 누르기
-        SchedulePostLikeRequest doSchedulePostLike = new SchedulePostLikeRequest(createdSchedulePostId, true);
-        Long afterLiked = schedulePostService.toggleSchedulePostLiked(testMemberId, doSchedulePostLike);
+        SchedulePostLikeRequest doSchedulePostLike = new SchedulePostLikeRequest(true);
+        Long afterLiked = schedulePostService.toggleSchedulePostLiked(testMemberId, createdSchedulePostId, doSchedulePostLike);
         // 좋아요 취소
-        SchedulePostLikeRequest doSchedulePostLikeAgain = new SchedulePostLikeRequest(createdSchedulePostId, false);
-        Long afterLikedAgain = schedulePostService.toggleSchedulePostLiked(testMemberId, doSchedulePostLikeAgain);
+        SchedulePostLikeRequest doSchedulePostLikeAgain = new SchedulePostLikeRequest(false);
+        Long afterLikedAgain = schedulePostService.toggleSchedulePostLiked(testMemberId, createdSchedulePostId, doSchedulePostLikeAgain);
 
         // 좋아요 누른 후 좋아요 수
         assertThat(beforeLiked + 1).isEqualTo(afterLiked);
@@ -370,12 +370,12 @@ class SchedulePostServiceTest {
         // 좋아요 한 게시글 없음
         List<SchedulePostResponse> emptySchedulePostList = schedulePostService.getLikedSchedulePosts(testMemberId);
         // 1번 여행 좋아요!
-        SchedulePostLikeRequest doSchedulePostLike1 = new SchedulePostLikeRequest(createdSchedulePostId1, true);
-        schedulePostService.toggleSchedulePostLiked(testMemberId, doSchedulePostLike1);
+        SchedulePostLikeRequest doSchedulePostLike1 = new SchedulePostLikeRequest(true);
+        schedulePostService.toggleSchedulePostLiked(testMemberId, createdSchedulePostId1, doSchedulePostLike1);
         List<SchedulePostResponse> schedulePostListAfterLikeTrip1 = schedulePostService.getLikedSchedulePosts(testMemberId);
         // 2번 여행도 좋아요!
-        SchedulePostLikeRequest doSchedulePostLike2 = new SchedulePostLikeRequest(createdSchedulePostId2, true);
-        schedulePostService.toggleSchedulePostLiked(testMemberId, doSchedulePostLike2);
+        SchedulePostLikeRequest doSchedulePostLike2 = new SchedulePostLikeRequest(true);
+        schedulePostService.toggleSchedulePostLiked(testMemberId, createdSchedulePostId2, doSchedulePostLike2);
         List<SchedulePostResponse> schedulePostListAfterLikeTrip2 = schedulePostService.getLikedSchedulePosts(testMemberId);
 
         // then

--- a/src/test/java/com/cocodan/triplan/post/schedule/service/SchedulePostServiceTest.java
+++ b/src/test/java/com/cocodan/triplan/post/schedule/service/SchedulePostServiceTest.java
@@ -354,7 +354,7 @@ class SchedulePostServiceTest {
         // 좋아요 취소
         SchedulePostLikeRequest doSchedulePostLikeAgain = new SchedulePostLikeRequest(false);
         Long afterLikedAgain = schedulePostService.toggleSchedulePostLiked(testMemberId, createdSchedulePostId, doSchedulePostLikeAgain);
-
+        
         // 좋아요 누른 후 좋아요 수
         assertThat(beforeLiked + 1).isEqualTo(afterLiked);
         // 좋아요 취소된 후 좋아요 수


### PR DESCRIPTION
* 원인: 게시글 삭제시 해당 게시글의 ID를 FK로 사용하는 다른 테이블들의 record가 먼저 삭제되어야 했음
* 조치
  * 게시글 삭제시 [대댓글 -> 댓글 -> 좋아요] 순으로 선행 삭제가 이루어 진 후 게시글 삭제.
  * 댓글 삭제시 해당 댓글의 대댓글 전체가 삭제된 후 댓글이 삭제됨

* 이 내용은 추후 댓글이 삭제되더라도 대댓글이 남아있을 수 있도록 수정되어야 합니다.