### PR TITLE
Fix : AuditorAware 에러 수정

### DIFF
--- a/src/main/java/com/cocodan/triplan/common/AuditorAwareImpl.java
+++ b/src/main/java/com/cocodan/triplan/common/AuditorAwareImpl.java
@@ -3,6 +3,7 @@ package com.cocodan.triplan.common;
 import com.cocodan.triplan.jwt.JwtAuthentication;
 import com.cocodan.triplan.jwt.JwtAuthenticationToken;
 import org.springframework.data.domain.AuditorAware;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 
@@ -13,13 +14,21 @@ public class AuditorAwareImpl implements AuditorAware<Long> {
 
     @Override
     public Optional<Long> getCurrentAuditor() {
-        JwtAuthenticationToken jwtAuthenticationToken = (JwtAuthenticationToken) SecurityContextHolder.getContext().getAuthentication();
+        return Optional.ofNullable(getUserId());
+    }
 
-        if (jwtAuthenticationToken == null) {
-            return Optional.empty();
+    private Long getUserId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null) {
+            return null;
         }
 
-        JwtAuthentication authentication = (JwtAuthentication) jwtAuthenticationToken.getPrincipal();
-        return Optional.of(authentication.getId());
+        Object principal = authentication.getPrincipal();
+
+        if (principal instanceof String) {
+            return null;
+        }
+
+        return ((JwtAuthentication) principal).getId();
     }
 }


### PR DESCRIPTION
원인 : 외부 클라이언트에서 요청이 들어오면 Security Filter에서 Authentication이 무조건 set됨.
하지만, 테스트 코드에서는  필터를 안 타므로 Authentication이 null인 상황 발생.

해결 방법
현재 비즈니스 로직에 authentication에 null체크를 넣어놈.

고민해봐야할 점.
이 코드는 사실 비즈니스 로직에선 전혀 필요 없는 코드 because 시큐리티 필터를 안 거치고 요청이 들어올 수 없으므로.
근데, 테스트 코드를 위해서 null 체크 코드를 비즈니스 로직에 넣어놓는 것이 맞는지 의문.