### PR TITLE
[TP-127] Feature : 로그 버전 update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,24 +130,8 @@
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-jul</artifactId>
+            <artifactId>log4j-to-slf4j</artifactId>
             <version>2.17.0</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
-            <version>2.17.0</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>1.7.32</version>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>jul-to-slf4j</artifactId>
-            <version>1.7.32</version>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
로그 classpath 여러 개 찾아졌던 문제 수정
- 원인 블로그에서 수정 사항이라고 pom.xml을 싹 긁어왔었는데, 
- 그 중에서 springboot가 기본으로 import하는 cq.qos.logback 과
- 새롭게 pom에 추가했던 log4j-slf4j-impl 이 충돌.
- 사실 log4j-slf4j-impl만 지워도 되긴 하지만, 용도를 모르는 jul 관련 dependency도 우선 삭제

결론
springboot가 기본으로 import하는 log4j-api 와 log4j-to-slf4j 버전 업데이트.
log4j 취약점에 영향받는 log4j-core 도 업데이트