### PR TITLE
[TP-104] 코드 컨벤션 2차 적용 및 리팩토링

### DIFF
--- a/src/main/java/com/cocodan/triplan/common/BaseEntity.java
+++ b/src/main/java/com/cocodan/triplan/common/BaseEntity.java
@@ -13,7 +13,7 @@ import java.time.LocalDateTime;
 
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
-public abstract class BaseEntity {
+public abstract class BaseEntity extends BaseTimeEntity{
 
     @CreatedBy
     @Column(name = "created_by", updatable = false)
@@ -22,14 +22,6 @@ public abstract class BaseEntity {
     @LastModifiedBy
     @Column(name = "last_modified_by")
     private Long lastModifiedBy;
-
-    @CreatedDate
-    @Column(name = "created_date")
-    private LocalDateTime createdDate;
-
-    @LastModifiedDate
-    @Column(name = "last_modified_date")
-    private LocalDateTime lastModifiedDate;
 
     protected BaseEntity() {
     }
@@ -44,13 +36,5 @@ public abstract class BaseEntity {
 
     public Long getLastModifiedBy() {
         return lastModifiedBy;
-    }
-
-    public LocalDateTime getCreatedDate() {
-        return createdDate;
-    }
-
-    public LocalDateTime getLastModifiedDate() {
-        return lastModifiedDate;
     }
 }

--- a/src/main/java/com/cocodan/triplan/common/BaseTimeEntity.java
+++ b/src/main/java/com/cocodan/triplan/common/BaseTimeEntity.java
@@ -1,0 +1,31 @@
+package com.cocodan.triplan.common;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(name = "created_date", updatable = false)
+    private LocalDateTime createdDate;
+
+    @LastModifiedDate
+    @Column(name = "last_modified_date")
+    private LocalDateTime lastModifiedDate;
+
+    public LocalDateTime getCreatedDate() {
+        return createdDate;
+    }
+
+    public LocalDateTime getLastModifiedDate() {
+        return lastModifiedDate;
+    }
+}

--- a/src/main/java/com/cocodan/triplan/common/dto/ApiResponse.java
+++ b/src/main/java/com/cocodan/triplan/common/dto/ApiResponse.java
@@ -1,0 +1,30 @@
+package com.cocodan.triplan.common.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Getter;
+
+@Getter
+public class ApiResponse<T> {
+
+    private int code;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private T result;
+
+    private ApiResponse(int code) {
+        this(code, null);
+    }
+
+    private ApiResponse(int code, T result) {
+        this.code = code;
+        this.result = result;
+    }
+
+    public static <T> ApiResponse<T> createApiResponse(int code) {
+        return new ApiResponse<>(code);
+    }
+
+    public static <T> ApiResponse<T> createApiResponse(int code, T result) {
+        return new ApiResponse<>(code, result);
+    }
+}

--- a/src/main/java/com/cocodan/triplan/member/domain/Member.java
+++ b/src/main/java/com/cocodan/triplan/member/domain/Member.java
@@ -1,5 +1,6 @@
 package com.cocodan.triplan.member.domain;
 
+import com.cocodan.triplan.common.BaseTimeEntity;
 import com.cocodan.triplan.member.domain.vo.GenderType;
 import com.cocodan.triplan.common.BaseEntity;
 import lombok.AccessLevel;
@@ -16,7 +17,7 @@ import java.util.Calendar;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @DynamicInsert
 @DynamicUpdate
-public class Member extends BaseEntity {
+public class Member extends BaseTimeEntity {
     private static final int BASIC_AGE = 1;
 
     @Id

--- a/src/main/java/com/cocodan/triplan/member/service/MemberService.java
+++ b/src/main/java/com/cocodan/triplan/member/service/MemberService.java
@@ -1,5 +1,6 @@
 package com.cocodan.triplan.member.service;
 
+import com.cocodan.triplan.exception.common.NotFoundException;
 import com.cocodan.triplan.exception.common.UniqueEmailException;
 import com.cocodan.triplan.member.dto.response.*;
 import com.cocodan.triplan.util.MemberConverter;
@@ -12,6 +13,8 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.text.MessageFormat;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -105,5 +108,14 @@ public class MemberService {
         }
 
         return member;
+    }
+
+    public Member findMemberById(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new NotFoundException(MessageFormat.format(
+                        "{} :: Member Not Found. " +
+                                "There does not exist a Member with the given ID : {}",
+                        LocalDateTime.now(), memberId
+                )));
     }
 }

--- a/src/main/java/com/cocodan/triplan/schedule/ScheduleConverter.java
+++ b/src/main/java/com/cocodan/triplan/schedule/ScheduleConverter.java
@@ -1,0 +1,92 @@
+package com.cocodan.triplan.schedule;
+
+import com.cocodan.triplan.schedule.domain.*;
+import com.cocodan.triplan.schedule.domain.vo.Theme;
+import com.cocodan.triplan.schedule.dto.request.*;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class ScheduleConverter {
+
+    public Checklist createChecklist(ChecklistCreationRequest request, Schedule schedule) {
+        return Checklist.builder()
+                .title(request.getTitle())
+                .schedule(schedule)
+                .day(request.getDay())
+                .build();
+    }
+
+    public Memo createMemo(MemoRequest request, Schedule schedule, Long memberId) {
+        return Memo.builder()
+                .schedule(schedule)
+                .title(request.getTitle())
+                .content(request.getContent())
+                .memberId(memberId)
+                .build();
+    }
+
+    public Voting createVoting(VotingCreationRequest request, Long memberId, Schedule schedule) {
+        return Voting.builder()
+                .schedule(schedule)
+                .title(request.getTitle())
+                .multipleFlag(request.isMultipleFlag())
+                .memberId(memberId)
+                .build();
+    }
+
+    public void createVotingContents(VotingCreationRequest request, Voting voting) {
+        request.getContents()
+                .forEach(content -> createVotingContent(voting, content));
+    }
+
+    public Schedule createSchedule(ScheduleCreationRequest request, Long memberId) {
+        return Schedule.builder()
+                .title(request.getTitle())
+                .startDate(request.getStartDate())
+                .endDate(request.getEndDate())
+                .memberId(memberId)
+                .build();
+    }
+
+    public void addAllScheduleMembers(ScheduleCreationRequest request, Schedule save) {
+        for (Long id : request.getIdsOfFriends()) {
+            createScheduleMember(save, id);
+        }
+    }
+
+    public void createScheduleMember(Schedule schedule, long memberId) {
+        ScheduleMember.builder()
+                .memberId(memberId)
+                .schedule(schedule)
+                .build();
+    }
+
+    public void createScheduleDailySpots(List<DailyScheduleSpotCreationRequest> requests, Schedule schedule) {
+        requests.forEach(spotRequest -> createDailyScheduleSpot(spotRequest, schedule));
+    }
+
+    public void createScheduleThemes(List<String> themes, Schedule schedule) {
+        themes.stream()
+                .map(s -> Theme.from(s.toUpperCase()))
+                .forEach(theme -> new ScheduleTheme(schedule, theme));
+    }
+
+    private void createVotingContent(Voting voting, String votingContentName) {
+        VotingContent.builder()
+                .voting(voting)
+                .content(votingContentName)
+                .build();
+    }
+
+    private void createDailyScheduleSpot(DailyScheduleSpotCreationRequest request, Schedule schedule) {
+        DailyScheduleSpot.builder()
+                .spotId(request.getSpotId())
+                .placeName(request.getPlaceName())
+                .dateOrder(request.getDateOrder())
+                .spotOrder(request.getSpotOrder())
+                .schedule(schedule)
+                .build();
+    }
+}

--- a/src/main/java/com/cocodan/triplan/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/cocodan/triplan/schedule/controller/ScheduleController.java
@@ -5,7 +5,7 @@ import com.cocodan.triplan.jwt.JwtAuthentication;
 import com.cocodan.triplan.member.dto.response.MemberSimpleResponse;
 import com.cocodan.triplan.schedule.dto.request.*;
 import com.cocodan.triplan.schedule.dto.response.*;
-import com.cocodan.triplan.schedule.service.ScheduleService;
+import com.cocodan.triplan.schedule.service.*;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +23,14 @@ import java.util.List;
 public class ScheduleController {
 
     private final ScheduleService scheduleService;
+
+    private final MemoService memoService;
+
+    private final VotingService votingService;
+
+    private final ChecklistService checklistService;
+
+    private final ScheduleMemberService scheduleMemberService;
 
     // 일정
     @ApiOperation("일정 생성")
@@ -85,7 +93,7 @@ public class ScheduleController {
             @RequestBody @Valid MemoRequest memoRequest,
             @AuthenticationPrincipal JwtAuthentication authentication
     ) {
-        Long savedId = scheduleService.saveMemo(scheduleId, memoRequest, authentication.getId());
+        Long savedId = memoService.saveMemo(scheduleId, memoRequest, authentication.getId());
 
         return ApiResponse.created(new IdResponse(savedId));
     }
@@ -96,7 +104,7 @@ public class ScheduleController {
             @PathVariable Long scheduleId,
             @AuthenticationPrincipal JwtAuthentication authentication
     ) {
-        List<MemoResponse> memos = scheduleService.getMemos(scheduleId, authentication.getId());
+        List<MemoResponse> memos = memoService.getMemos(scheduleId, authentication.getId());
 
         return ApiResponse.ok(memos);
     }
@@ -108,7 +116,7 @@ public class ScheduleController {
             @PathVariable Long memoId,
             @AuthenticationPrincipal JwtAuthentication authentication
     ) {
-        MemoResponse memoResponse = scheduleService.getMemo(scheduleId, memoId, authentication.getId());
+        MemoResponse memoResponse = memoService.getMemo(scheduleId, memoId, authentication.getId());
 
         return ApiResponse.ok(memoResponse);
     }
@@ -121,7 +129,7 @@ public class ScheduleController {
             @RequestBody @Valid MemoRequest memoRequest,
             @AuthenticationPrincipal JwtAuthentication authentication
     ) {
-        scheduleService.modifyMemo(scheduleId, memoId, memoRequest, authentication.getId());
+        memoService.modifyMemo(scheduleId, memoId, memoRequest, authentication.getId());
 
         return ApiResponse.ok();
     }
@@ -133,7 +141,7 @@ public class ScheduleController {
             @PathVariable Long memoId,
             @AuthenticationPrincipal JwtAuthentication authentication
     ) {
-        scheduleService.deleteMemo(scheduleId, memoId, authentication.getId());
+        memoService.deleteMemo(scheduleId, memoId, authentication.getId());
 
         return ApiResponse.ok();
     }
@@ -146,7 +154,7 @@ public class ScheduleController {
             @RequestBody @Valid ChecklistCreationRequest checklistCreationRequest,
             @AuthenticationPrincipal JwtAuthentication authentication
     ) {
-        Long savedId = scheduleService.saveChecklist(scheduleId, checklistCreationRequest, authentication.getId());
+        Long savedId = checklistService.saveChecklist(scheduleId, checklistCreationRequest, authentication.getId());
 
         return ApiResponse.created(new IdResponse(savedId));
     }
@@ -157,7 +165,7 @@ public class ScheduleController {
             @PathVariable Long scheduleId,
             @AuthenticationPrincipal JwtAuthentication authentication
     ) {
-        List<ChecklistResponse> checklistResponses = scheduleService.getChecklists(scheduleId, authentication.getId());
+        List<ChecklistResponse> checklistResponses = checklistService.getChecklists(scheduleId, authentication.getId());
 
         return ApiResponse.ok(checklistResponses);
     }
@@ -170,7 +178,7 @@ public class ScheduleController {
             @RequestParam boolean flag,
             @AuthenticationPrincipal JwtAuthentication authentication
     ) {
-        scheduleService.doCheck(scheduleId, checklistId, authentication.getId(), flag);
+        checklistService.doCheck(scheduleId, checklistId, authentication.getId(), flag);
 
         return ApiResponse.ok();
     }
@@ -182,7 +190,7 @@ public class ScheduleController {
             @PathVariable Long checklistId,
             @AuthenticationPrincipal JwtAuthentication authentication
     ) {
-        scheduleService.deleteChecklist(scheduleId, checklistId, authentication.getId());
+        checklistService.deleteChecklist(scheduleId, checklistId, authentication.getId());
 
         return ApiResponse.ok();
     }
@@ -195,7 +203,7 @@ public class ScheduleController {
             @RequestBody @Valid VotingCreationRequest votingCreationRequest,
             @AuthenticationPrincipal JwtAuthentication authentication
     ) {
-        Long savedId = scheduleService.saveVoting(scheduleId, votingCreationRequest, authentication.getId());
+        Long savedId = votingService.saveVoting(scheduleId, votingCreationRequest, authentication.getId());
 
         return ApiResponse.created(new IdResponse(savedId));
     }
@@ -207,7 +215,7 @@ public class ScheduleController {
             @AuthenticationPrincipal JwtAuthentication authentication
     ) {
         List<VotingResponse> votingSimpleResponses =
-                scheduleService.getVotingList(scheduleId, authentication.getId());
+                votingService.getVotingList(scheduleId, authentication.getId());
 
         return ApiResponse.ok(votingSimpleResponses);
     }
@@ -220,7 +228,7 @@ public class ScheduleController {
             @AuthenticationPrincipal JwtAuthentication authentication
     ) {
         VotingResponse votingResponse =
-                scheduleService.getVoting(scheduleId, votingId, authentication.getId());
+                votingService.getVoting(scheduleId, votingId, authentication.getId());
 
         return ApiResponse.ok(votingResponse);
     }
@@ -233,7 +241,7 @@ public class ScheduleController {
             @RequestBody @Valid VotingRequest votingRequest,
             @AuthenticationPrincipal JwtAuthentication authentication
     ) {
-        scheduleService.doVote(scheduleId, votingId, votingRequest, authentication.getId());
+        votingService.doVote(scheduleId, votingId, votingRequest, authentication.getId());
 
         return ApiResponse.ok();
     }
@@ -245,7 +253,7 @@ public class ScheduleController {
             @PathVariable Long votingId,
             @AuthenticationPrincipal JwtAuthentication authentication
     ) {
-        scheduleService.deleteVoting(scheduleId, votingId, authentication.getId());
+        votingService.deleteVoting(scheduleId, votingId, authentication.getId());
 
         return ApiResponse.ok();
     }
@@ -258,7 +266,7 @@ public class ScheduleController {
             @Valid @RequestBody ScheduleMemberRequest scheduleMemberRequest,
             @AuthenticationPrincipal JwtAuthentication authentication
     ) {
-        scheduleService.addScheduleMember(scheduleId, scheduleMemberRequest, authentication.getId());
+        scheduleMemberService.addScheduleMember(scheduleId, scheduleMemberRequest, authentication.getId());
 
         return ApiResponse.ok();
     }
@@ -270,7 +278,7 @@ public class ScheduleController {
             @AuthenticationPrincipal JwtAuthentication authentication
     ) {
         List<MemberSimpleResponse> memberSimpleResponses =
-                scheduleService.getScheduleMembers(scheduleId, authentication.getId());
+                scheduleMemberService.getScheduleMembers(scheduleId, authentication.getId());
 
         return ApiResponse.ok(memberSimpleResponses);
     }
@@ -282,7 +290,7 @@ public class ScheduleController {
             @PathVariable(name = "memberId") Long deletedId,
             @AuthenticationPrincipal JwtAuthentication authentication
     ) {
-        scheduleService.deleteScheduleMember(scheduleId, deletedId, authentication.getId());
+        scheduleMemberService.deleteScheduleMember(scheduleId, deletedId, authentication.getId());
 
         return ApiResponse.ok();
     }
@@ -293,7 +301,7 @@ public class ScheduleController {
             @PathVariable Long scheduleId,
             @AuthenticationPrincipal JwtAuthentication authentication
     ) {
-        scheduleService.exitSchedule(scheduleId, authentication.getId());
+        scheduleMemberService.exitSchedule(scheduleId, authentication.getId());
 
         return ApiResponse.ok();
     }

--- a/src/main/java/com/cocodan/triplan/schedule/dto/request/DailyScheduleSpotCreationRequest.java
+++ b/src/main/java/com/cocodan/triplan/schedule/dto/request/DailyScheduleSpotCreationRequest.java
@@ -39,5 +39,4 @@ public class DailyScheduleSpotCreationRequest {
 
     @Range(min = Schedule.NUM_OF_SPOT_MIN, max = Schedule.NUM_OF_SPOT_MAX)
     private int spotOrder;
-
 }

--- a/src/main/java/com/cocodan/triplan/schedule/dto/request/ScheduleModificationRequest.java
+++ b/src/main/java/com/cocodan/triplan/schedule/dto/request/ScheduleModificationRequest.java
@@ -23,5 +23,4 @@ public class ScheduleModificationRequest {
 
     @NotNull
     private List<DailyScheduleSpotCreationRequest> dailyScheduleSpotCreationRequests;
-
 }

--- a/src/main/java/com/cocodan/triplan/schedule/service/ChecklistService.java
+++ b/src/main/java/com/cocodan/triplan/schedule/service/ChecklistService.java
@@ -2,6 +2,7 @@ package com.cocodan.triplan.schedule.service;
 
 import com.cocodan.triplan.exception.common.NotFoundException;
 import com.cocodan.triplan.exception.common.NotIncludeException;
+import com.cocodan.triplan.schedule.ScheduleConverter;
 import com.cocodan.triplan.schedule.domain.Checklist;
 import com.cocodan.triplan.schedule.domain.Schedule;
 import com.cocodan.triplan.schedule.dto.request.ChecklistCreationRequest;
@@ -24,13 +25,15 @@ public class ChecklistService {
 
     private final ScheduleService scheduleService;
 
+    private final ScheduleConverter converter;
+
     @Transactional
     public Long saveChecklist(Long scheduleId, ChecklistCreationRequest checklistCreationRequest, Long memberId) {
         Schedule schedule = scheduleService.findScheduleById(scheduleId);
 
         scheduleService.validateScheduleMember(scheduleId, memberId);
 
-        Checklist checklist = createChecklist(checklistCreationRequest, schedule);
+        Checklist checklist = converter.createChecklist(checklistCreationRequest, schedule);
 
         return checklistRepository.save(checklist).getId();
     }
@@ -64,14 +67,6 @@ public class ChecklistService {
         scheduleService.validateScheduleMember(scheduleId, memberId);
 
         checklistRepository.delete(checklist);
-    }
-
-    private Checklist createChecklist(ChecklistCreationRequest checklistCreationRequest, Schedule schedule) {
-        return Checklist.builder()
-                .title(checklistCreationRequest.getTitle())
-                .schedule(schedule)
-                .day(checklistCreationRequest.getDay())
-                .build();
     }
 
     private Checklist findChecklistById(Long checklistId) {

--- a/src/main/java/com/cocodan/triplan/schedule/service/ChecklistService.java
+++ b/src/main/java/com/cocodan/triplan/schedule/service/ChecklistService.java
@@ -1,0 +1,94 @@
+package com.cocodan.triplan.schedule.service;
+
+import com.cocodan.triplan.exception.common.NotFoundException;
+import com.cocodan.triplan.exception.common.NotIncludeException;
+import com.cocodan.triplan.schedule.domain.Checklist;
+import com.cocodan.triplan.schedule.domain.Schedule;
+import com.cocodan.triplan.schedule.dto.request.ChecklistCreationRequest;
+import com.cocodan.triplan.schedule.dto.response.ChecklistResponse;
+import com.cocodan.triplan.schedule.repository.ChecklistRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.text.MessageFormat;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ChecklistService {
+
+    private final ChecklistRepository checklistRepository;
+
+    private final ScheduleService scheduleService;
+
+    @Transactional
+    public Long saveChecklist(Long scheduleId, ChecklistCreationRequest checklistCreationRequest, Long memberId) {
+        Schedule schedule = scheduleService.findScheduleById(scheduleId);
+
+        scheduleService.validateScheduleMember(scheduleId, memberId);
+
+        Checklist checklist = createChecklist(checklistCreationRequest, schedule);
+
+        return checklistRepository.save(checklist).getId();
+    }
+
+    @Transactional(readOnly = true)
+    public List<ChecklistResponse> getChecklists(Long scheduleId, Long memberId) {
+        scheduleService.validateScheduleMember(scheduleId, memberId);
+
+        return checklistRepository.findByScheduleId(scheduleId).stream()
+                .map(ChecklistResponse::from)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public void doCheck(Long scheduleId, Long checklistId, Long memberId, boolean flag) {
+        Checklist checklist = findChecklistById(checklistId);
+
+        validateScheduleChecklist(scheduleId, checklistId);
+
+        scheduleService.validateScheduleMember(scheduleId, memberId);
+
+        checklist.check(flag);
+    }
+
+    @Transactional
+    public void deleteChecklist(Long scheduleId, Long checklistId, Long memberId) {
+        Checklist checklist = findChecklistById(checklistId);
+
+        validateScheduleChecklist(scheduleId, checklistId);
+
+        scheduleService.validateScheduleMember(scheduleId, memberId);
+
+        checklistRepository.delete(checklist);
+    }
+
+    private Checklist createChecklist(ChecklistCreationRequest checklistCreationRequest, Schedule schedule) {
+        return Checklist.builder()
+                .title(checklistCreationRequest.getTitle())
+                .schedule(schedule)
+                .day(checklistCreationRequest.getDay())
+                .build();
+    }
+
+    private Checklist findChecklistById(Long checklistId) {
+        return checklistRepository.findById(checklistId)
+                .orElseThrow(() -> new NotFoundException(MessageFormat.format(
+                        "{} :: Checklist Not Found. " +
+                                "There does not exist a Checklist with the given ID : {}",
+                        LocalDateTime.now(), checklistId
+                )));
+    }
+
+    private void validateScheduleChecklist(Long scheduleId, Long checklistId) {
+        boolean notExists = !checklistRepository.existsByIdAndScheduleId(checklistId, scheduleId);
+
+        if (notExists) {
+            throw new NotIncludeException(Schedule.class, Checklist.class, scheduleId, checklistId);
+        }
+    }
+
+}

--- a/src/main/java/com/cocodan/triplan/schedule/service/MemoService.java
+++ b/src/main/java/com/cocodan/triplan/schedule/service/MemoService.java
@@ -1,0 +1,121 @@
+package com.cocodan.triplan.schedule.service;
+
+import com.cocodan.triplan.exception.common.ForbiddenException;
+import com.cocodan.triplan.exception.common.NotFoundException;
+import com.cocodan.triplan.exception.common.NotIncludeException;
+import com.cocodan.triplan.member.domain.Member;
+import com.cocodan.triplan.member.service.MemberService;
+import com.cocodan.triplan.schedule.domain.Memo;
+import com.cocodan.triplan.schedule.domain.Schedule;
+import com.cocodan.triplan.schedule.dto.request.MemoRequest;
+import com.cocodan.triplan.schedule.dto.response.MemoResponse;
+import com.cocodan.triplan.schedule.repository.MemoRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.text.MessageFormat;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class MemoService {
+
+    private final MemoRepository memoRepository;
+
+    private final ScheduleService scheduleService;
+
+    private final MemberService memberService;
+
+    @Transactional
+    public Long saveMemo(Long scheduleId, MemoRequest memoRequest, Long memberId) {
+        Schedule schedule = scheduleService.findScheduleById(scheduleId);
+
+        scheduleService.validateScheduleMember(scheduleId, memberId);
+
+        Memo memo = createMemo(memoRequest, schedule, memberId);
+
+        return memoRepository.save(memo).getId();
+    }
+
+    @Transactional(readOnly = true)
+    public List<MemoResponse> getMemos(Long scheduleId, Long memberId) {
+        scheduleService.validateScheduleMember(scheduleId, memberId);
+
+        return memoRepository.findByScheduleId(scheduleId)
+                .stream()
+                .map(MemoResponse::from)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public MemoResponse getMemo(Long scheduleId, Long memoId, Long memberId) {
+        Memo memo = findMemoById(memoId);
+
+        validateScheduleMemo(scheduleId, memoId);
+
+        scheduleService.validateScheduleMember(scheduleId, memberId);
+
+        Long ownerId = memo.getMemberId();
+
+        Member member = memberService.findMemberById(ownerId);
+
+        return MemoResponse.of(memo, member);
+    }
+
+    private void validateScheduleMemo(Long scheduleId, Long memoId) {
+        boolean notExists = !memoRepository.existsByIdAndScheduleId(memoId, scheduleId);
+
+        if (notExists) {
+            throw new NotIncludeException(Schedule.class, Memo.class, scheduleId, memoId);
+        }
+    }
+
+    @Transactional
+    public void modifyMemo(Long scheduleId, Long memoId, MemoRequest memoRequest, Long memberId) {
+        Memo memo = findMemoById(memoId);
+
+        validateScheduleMemo(scheduleId, memoId);
+
+        validateMemoOwner(memo, memberId);
+
+        memo.modify(memoRequest.getTitle(), memoRequest.getContent());
+    }
+
+    @Transactional
+    public void deleteMemo(Long scheduleId, Long memoId, Long memberId) {
+        Memo memo = findMemoById(memoId);
+
+        validateScheduleMemo(scheduleId, memoId);
+
+        validateMemoOwner(memo, memberId);
+
+        memoRepository.delete(memo);
+    }
+
+    private Memo createMemo(MemoRequest memoRequest, Schedule schedule, Long memberId) {
+        return Memo.builder()
+                .schedule(schedule)
+                .title(memoRequest.getTitle())
+                .content(memoRequest.getContent())
+                .memberId(memberId)
+                .build();
+    }
+
+    private Memo findMemoById(Long memoId) {
+        return memoRepository.findById(memoId)
+                .orElseThrow(() -> new NotFoundException(MessageFormat.format(
+                        "{} :: Memo Not Found. " +
+                                "There does not exist a Memo with the given ID : {}",
+                        LocalDateTime.now(), memoId
+                )));
+    }
+
+    private void validateMemoOwner(Memo memo, Long memberId) {
+        if (!memo.getMemberId().equals(memberId)) {
+            throw new ForbiddenException(Memo.class, memo.getId(), memberId);
+        }
+    }
+}

--- a/src/main/java/com/cocodan/triplan/schedule/service/ScheduleMemberService.java
+++ b/src/main/java/com/cocodan/triplan/schedule/service/ScheduleMemberService.java
@@ -1,0 +1,115 @@
+package com.cocodan.triplan.schedule.service;
+
+import com.cocodan.triplan.exception.common.NoFriendsException;
+import com.cocodan.triplan.friend.repository.FriendRepository;
+import com.cocodan.triplan.member.dto.response.MemberSimpleResponse;
+import com.cocodan.triplan.member.repository.MemberRepository;
+import com.cocodan.triplan.schedule.domain.Schedule;
+import com.cocodan.triplan.schedule.domain.ScheduleMember;
+import com.cocodan.triplan.schedule.dto.request.ScheduleCreationRequest;
+import com.cocodan.triplan.schedule.dto.request.ScheduleMemberRequest;
+import com.cocodan.triplan.schedule.repository.ScheduleRepository;
+import com.cocodan.triplan.util.ExceptionMessageUtils;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ScheduleMemberService {
+
+    private final ScheduleRepository scheduleRepository;
+
+    private final MemberRepository memberRepository;
+
+    private final FriendRepository friendRepository;
+
+    private final ScheduleService scheduleService;
+
+    // 여행 멤버
+    @Transactional
+    public void addScheduleMember(Long scheduleId, ScheduleMemberRequest scheduleMemberRequest, Long memberId) {
+        Schedule schedule = scheduleService.findScheduleById(scheduleId);
+
+        scheduleService.validateScheduleMember(scheduleId, memberId);
+
+        long friendId = scheduleMemberRequest.getFriendId();
+
+        validateFriends(friendId, memberId);
+
+        createScheduleMember(schedule, friendId);
+    }
+
+    @Transactional(readOnly = true)
+    public List<MemberSimpleResponse> getScheduleMembers(Long scheduleId, Long memberId) {
+        Schedule schedule = scheduleService.findScheduleById(scheduleId);
+
+        scheduleService.validateScheduleMember(scheduleId, memberId);
+
+        List<Long> ids = schedule.getScheduleMembers().stream()
+                .map(ScheduleMember::getMemberId)
+                .collect(Collectors.toList());
+
+        return memberRepository.findByIdIn(ids)
+                .stream()
+                .map(MemberSimpleResponse::from)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public void deleteScheduleMember(Long scheduleId, Long deletedId, Long memberId) {
+        Schedule schedule = scheduleService.findScheduleById(scheduleId);
+
+        scheduleService.validateScheduleMember(scheduleId, memberId);
+
+        if (scheduleService.isConstructor(schedule, deletedId)) {
+            throw new IllegalArgumentException(ExceptionMessageUtils.getMessage("exception.bad_request"));
+        }
+
+        ScheduleMember deletedMember = findDeletedMember(schedule, deletedId);
+
+        schedule.deleteScheduleMember(deletedMember);
+    }
+
+    @Transactional
+    public void exitSchedule(Long scheduleId, Long memberId) {
+        Schedule schedule = scheduleService.findScheduleById(scheduleId);
+
+        scheduleService.validateScheduleMember(scheduleId, memberId);
+
+        if (memberId.equals(schedule.getMemberId())) {
+            scheduleRepository.delete(schedule);
+            return;
+        }
+
+        ScheduleMember deletedMember = findDeletedMember(schedule, memberId);
+
+        schedule.deleteScheduleMember(deletedMember);
+    }
+
+    private void createScheduleMember(Schedule schedule, long friendId) {
+        ScheduleMember.builder()
+                .memberId(friendId)
+                .schedule(schedule)
+                .build();
+    }
+
+    private void validateFriends(long friendId, Long memberId) {
+        friendRepository.findByFromIdAndToId(memberId, friendId)
+                .orElseThrow(() -> new NoFriendsException(friendId, memberId));
+    }
+
+    private ScheduleMember findDeletedMember(Schedule schedule, Long deletedId) {
+        return schedule.getScheduleMembers().stream()
+                .filter(scheduleMember -> scheduleMember.getMemberId().equals(deletedId))
+                .findFirst()
+                .orElseThrow(
+                        () -> new IllegalArgumentException(
+                                ExceptionMessageUtils.getMessage("exception.bad_request")
+                        )
+                );
+    }
+}

--- a/src/main/java/com/cocodan/triplan/schedule/service/ScheduleMemberService.java
+++ b/src/main/java/com/cocodan/triplan/schedule/service/ScheduleMemberService.java
@@ -4,6 +4,7 @@ import com.cocodan.triplan.exception.common.NoFriendsException;
 import com.cocodan.triplan.friend.repository.FriendRepository;
 import com.cocodan.triplan.member.dto.response.MemberSimpleResponse;
 import com.cocodan.triplan.member.repository.MemberRepository;
+import com.cocodan.triplan.schedule.ScheduleConverter;
 import com.cocodan.triplan.schedule.domain.Schedule;
 import com.cocodan.triplan.schedule.domain.ScheduleMember;
 import com.cocodan.triplan.schedule.dto.request.ScheduleCreationRequest;
@@ -29,6 +30,8 @@ public class ScheduleMemberService {
 
     private final ScheduleService scheduleService;
 
+    private final ScheduleConverter converter;
+
     // 여행 멤버
     @Transactional
     public void addScheduleMember(Long scheduleId, ScheduleMemberRequest scheduleMemberRequest, Long memberId) {
@@ -36,11 +39,9 @@ public class ScheduleMemberService {
 
         scheduleService.validateScheduleMember(scheduleId, memberId);
 
-        long friendId = scheduleMemberRequest.getFriendId();
+        validateFriends(scheduleMemberRequest.getFriendId(), memberId);
 
-        validateFriends(friendId, memberId);
-
-        createScheduleMember(schedule, friendId);
+        converter.createScheduleMember(schedule, scheduleMemberRequest.getFriendId());
     }
 
     @Transactional(readOnly = true)
@@ -88,13 +89,6 @@ public class ScheduleMemberService {
         ScheduleMember deletedMember = findDeletedMember(schedule, memberId);
 
         schedule.deleteScheduleMember(deletedMember);
-    }
-
-    private void createScheduleMember(Schedule schedule, long friendId) {
-        ScheduleMember.builder()
-                .memberId(friendId)
-                .schedule(schedule)
-                .build();
     }
 
     private void validateFriends(long friendId, Long memberId) {

--- a/src/main/java/com/cocodan/triplan/schedule/service/ScheduleService.java
+++ b/src/main/java/com/cocodan/triplan/schedule/service/ScheduleService.java
@@ -5,7 +5,6 @@ import com.cocodan.triplan.exception.common.NoFriendsException;
 import com.cocodan.triplan.exception.common.NotFoundException;
 import com.cocodan.triplan.exception.common.NotIncludeException;
 import com.cocodan.triplan.friend.repository.FriendRepository;
-import com.cocodan.triplan.jwt.JwtAuthentication;
 import com.cocodan.triplan.member.domain.Member;
 import com.cocodan.triplan.member.dto.response.MemberSimpleResponse;
 import com.cocodan.triplan.member.repository.MemberRepository;
@@ -35,17 +34,9 @@ public class ScheduleService {
 
     private final ScheduleRepository scheduleRepository;
 
-    private final SpotService spotService;
-
     private final MemberRepository memberRepository;
 
-    private final MemoRepository memoRepository;
-
-    private final ChecklistRepository checklistRepository;
-
-    private final VotingRepository votingRepository;
-
-    private final FriendRepository friendRepository;
+    private final SpotService spotService;
 
     @Transactional
     public Long saveSchedule(ScheduleCreationRequest scheduleCreationRequest, Long memberId) {
@@ -63,16 +54,87 @@ public class ScheduleService {
         return save.getId();
     }
 
-    private void addScheduleMember(ScheduleCreationRequest scheduleCreationRequest, Schedule save) {
-        for (Long id : scheduleCreationRequest.getIdsOfFriends()) {
-            createScheduleMember(save, id);
+    @Transactional(readOnly = true)
+    public List<ScheduleResponse> getSchedules(Long memberId) {
+        return scheduleRepository.findByMemberId(memberId)
+                .stream()
+                .map(ScheduleResponse::from)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public ScheduleResponse getSchedule(Long scheduleId) {
+        Schedule schedule = scheduleRepository.findOneWithSpotsById(scheduleId)
+                .orElseThrow(() -> new NotFoundException(MessageFormat.format(
+                        "{} :: Schedule Not Found. " +
+                                "There does not exist a Schedule with the given ID : {}",
+                        LocalDateTime.now(), scheduleId
+                )));
+
+        List<Long> scheduleMemberIds = getMemberIds(schedule);
+
+        List<Member> members = memberRepository.findByIdIn(scheduleMemberIds);
+
+        List<Spot> spots = spotService.findByIdIn(getSpotIds(schedule));
+
+        return ScheduleResponse.of(schedule, spots, members);
+    }
+
+    @Transactional
+    public void modifySchedule(Long scheduleId, ScheduleModificationRequest scheduleModificationRequest, Long memberId) {
+        Schedule schedule = findScheduleById(scheduleId);
+
+        validateScheduleMember(scheduleId, memberId);
+
+        scheduleModificationRequest.getDailyScheduleSpotCreationRequests()
+                .forEach(this::saveSpot);
+
+        schedule.updateTitle(scheduleModificationRequest.getTitle());
+
+        schedule.clearThemes();
+        createScheduleThemes(scheduleModificationRequest.getThemes(), schedule);
+
+        schedule.removeAllSpots();
+        convertDailyScheduleSpotList(schedule, scheduleModificationRequest);
+    }
+
+    @Transactional
+    public void deleteSchedule(Long scheduleId, Long memberId) {
+        Schedule schedule = findScheduleById(scheduleId);
+
+        if (!isConstructor(schedule, memberId)) {
+            throw new ForbiddenException(Schedule.class, schedule.getId(), memberId);
+        }
+
+        scheduleRepository.delete(schedule);
+    }
+
+    public Schedule findScheduleById(Long scheduleId) {
+        return scheduleRepository.findById(scheduleId)
+                .orElseThrow(() -> new NotFoundException(MessageFormat.format(
+                        "{} :: Schedule Not Found. " +
+                                "There does not exist a Schedule with the given ID : {}",
+                        LocalDateTime.now(), scheduleId
+                )));
+    }
+
+    public void validateScheduleMember(Long scheduleId, Long memberId) {
+        if (scheduleRepository.countByScheduleIdAndMemberId(scheduleId, memberId) == 0) {
+            throw new ForbiddenException(Schedule.class, scheduleId, memberId);
         }
     }
 
-    private void saveSpot(DailyScheduleSpotCreationRequest dailyScheduleSpotCreationRequest) {
-        if (isNotSavedSpot(dailyScheduleSpotCreationRequest)) {
-            spotService.createSpot(dailyScheduleSpotCreationRequest);
-        }
+    public boolean isConstructor(Schedule schedule, Long memberId) {
+        return schedule.getMemberId().equals(memberId);
+    }
+
+    public Member findMemberById(Long ownerId) {
+        return memberRepository.findById(ownerId)
+                .orElseThrow(() -> new NotFoundException(MessageFormat.format(
+                        "{} :: Member Not Found. " +
+                                "There does not exist a Member with the given ID : {}",
+                        LocalDateTime.now(), ownerId
+                )));
     }
 
     private Schedule convertSchedule(ScheduleCreationRequest scheduleCreationRequest, Long memberId) {
@@ -83,6 +145,19 @@ public class ScheduleService {
         createScheduleDailySpots(scheduleCreationRequest, schedule);
 
         return schedule;
+    }
+
+    private void addScheduleMember(ScheduleCreationRequest scheduleCreationRequest, Schedule save) {
+        for (Long id : scheduleCreationRequest.getIdsOfFriends()) {
+            createScheduleMember(save, id);
+        }
+    }
+
+    public void createScheduleMember(Schedule schedule, long friendId) {
+        ScheduleMember.builder()
+                .memberId(friendId)
+                .schedule(schedule)
+                .build();
     }
 
     private void createOwner(Schedule schedule, Long memberId) {
@@ -99,13 +174,6 @@ public class ScheduleService {
                 .endDate(scheduleCreationRequest.getEndDate())
                 .memberId(memberId)
                 .build();
-    }
-
-    private void createScheduleThemes(List<String> themes, Schedule schedule) {
-        themes
-                .stream()
-                .map(s -> Theme.from(s.toUpperCase()))
-                .forEach(theme -> new ScheduleTheme(schedule, theme));
     }
 
     private void createScheduleDailySpots(ScheduleCreationRequest scheduleCreationRequest, Schedule schedule) {
@@ -130,38 +198,16 @@ public class ScheduleService {
         return !spotService.existsById(dailyScheduleSpotCreationRequest.getSpotId());
     }
 
-    @Transactional(readOnly = true)
-    public List<ScheduleResponse> getSchedules(Long memberId) {
-        return scheduleRepository.findByMemberId(memberId)
-                .stream()
-                .map(ScheduleResponse::from)
-                .collect(Collectors.toList());
+    private void saveSpot(DailyScheduleSpotCreationRequest dailyScheduleSpotCreationRequest) {
+        if (isNotSavedSpot(dailyScheduleSpotCreationRequest)) {
+            spotService.createSpot(dailyScheduleSpotCreationRequest);
+        }
     }
 
-    @Transactional(readOnly = true)
-    public ScheduleResponse getSchedule(Long scheduleId) {
-        Schedule schedule = scheduleRepository.findOneWithSpotsById(scheduleId)
-                .orElseThrow(
-                        () -> new NotFoundException(
-                                MessageFormat.format(
-                                        "{} :: Schedule Not Found. " +
-                                                "There does not exist a Schedule with the given ID : {}",
-                                                // "\n\tRequested by a member(ID: {}, Token: {}",
-                                        LocalDateTime.now(),
-                                        scheduleId
-                                        // authentication.getId(),
-                                        // authentication.getToken()
-                                )
-                        )
-                );
-
-        List<Long> scheduleMemberIds = getMemberIds(schedule);
-
-        List<Member> members = memberRepository.findByIdIn(scheduleMemberIds);
-
-        List<Spot> spots = spotService.findByIdIn(getSpotIds(schedule));
-
-        return ScheduleResponse.of(schedule, spots, members);
+    private void createScheduleThemes(List<String> themes, Schedule schedule) {
+        themes.stream()
+                .map(s -> Theme.from(s.toUpperCase()))
+                .forEach(theme -> new ScheduleTheme(schedule, theme));
     }
 
     private List<Long> getMemberIds(Schedule schedule) {
@@ -176,451 +222,11 @@ public class ScheduleService {
                 .collect(Collectors.toList());
     }
 
-    @Transactional
-    public void modifySchedule(Long scheduleId, ScheduleModificationRequest scheduleModificationRequest, Long memberId) {
-        Schedule schedule = findScheduleById(scheduleId);
-
-        validateScheduleMember(scheduleId, memberId);
-
-        scheduleModificationRequest.getDailyScheduleSpotCreationRequests()
-                .forEach(this::saveSpot);
-
-        schedule.updateTitle(scheduleModificationRequest.getTitle());
-
-        schedule.clearThemes();
-        createScheduleThemes(scheduleModificationRequest.getThemes(), schedule);
-
-        schedule.removeAllSpots();
-        convertDailyScheduleSpotList(schedule, scheduleModificationRequest);
-    }
-
-    private Schedule findScheduleById(Long scheduleId) {
-        return scheduleRepository.findById(scheduleId)
-                .orElseThrow(
-                        () -> new NotFoundException(
-                                // TODO: [TP-126] Teru - 로깅 양식 통일 -> Controller & Service 전반적인 수정 필요
-                                MessageFormat.format(
-                                        "{} :: Schedule Not Found. " +
-                                                "There does not exist a Schedule with the given ID : {}",
-                                                // "\n\tRequested by a member(ID: {}, Token: {}",
-                                        LocalDateTime.now(),
-                                        scheduleId
-                                        // authentication.getId(),
-                                        // authentication.getToken()
-                                )
-                        )
-                );
-    }
-
-    private void validateScheduleMember(Long scheduleId, Long memberId) {
-        if (scheduleRepository.countByScheduleIdAndMemberId(scheduleId, memberId) == 0) {
-            throw new ForbiddenException(Schedule.class, scheduleId, memberId);
-        }
-    }
-
     private void convertDailyScheduleSpotList(
             Schedule schedule,
             ScheduleModificationRequest scheduleModificationRequest
     ) {
         scheduleModificationRequest.getDailyScheduleSpotCreationRequests()
                 .forEach(request -> createDailyScheduleSpot(schedule, request));
-    }
-
-    @Transactional
-    public void deleteSchedule(Long scheduleId, Long memberId) {
-        Schedule schedule = findScheduleById(scheduleId);
-
-        if (!isConstructor(schedule, memberId)) {
-            throw new ForbiddenException(Schedule.class, schedule.getId(), memberId);
-        }
-
-        scheduleRepository.delete(schedule);
-    }
-
-    private boolean isConstructor(Schedule schedule, Long memberId) {
-        return schedule.getMemberId().equals(memberId);
-    }
-
-    @Transactional
-    public Long saveMemo(Long scheduleId, MemoRequest memoRequest, Long memberId) {
-        Schedule schedule = findScheduleById(scheduleId);
-
-        validateScheduleMember(scheduleId, memberId);
-
-        Memo memo = createMemo(memoRequest, schedule, memberId);
-
-        return memoRepository.save(memo).getId();
-    }
-
-    private Memo createMemo(MemoRequest memoRequest, Schedule schedule, Long memberId) {
-        return Memo.builder()
-                .schedule(schedule)
-                .title(memoRequest.getTitle())
-                .content(memoRequest.getContent())
-                .memberId(memberId)
-                .build();
-    }
-
-
-    @Transactional(readOnly = true)
-    public List<MemoResponse> getMemos(Long scheduleId, Long memberId) {
-        validateScheduleMember(scheduleId, memberId);
-
-        return memoRepository.findByScheduleId(scheduleId)
-                .stream()
-                .map(MemoResponse::from)
-                .collect(Collectors.toList());
-    }
-
-    @Transactional(readOnly = true)
-    public MemoResponse getMemo(Long scheduleId, Long memoId, Long memberId) {
-        Memo memo = findMemoById(memoId);
-
-        validateScheduleMemo(scheduleId, memoId);
-
-        validateScheduleMember(scheduleId, memberId);
-
-        Long ownerId = memo.getMemberId();
-
-        Member member = findMemberById(ownerId);
-
-        return MemoResponse.of(memo, member);
-    }
-
-    private Member findMemberById(Long ownerId) {
-        return memberRepository.findById(ownerId)
-                .orElseThrow(() -> new NotFoundException(
-                        MessageFormat.format(
-                                "{} :: Member Not Found. " +
-                                        "There does not exist a Member with the given ID : {}",
-                                        // "\n\tRequested by a member(ID: {}, Token: {}",
-                                LocalDateTime.now(),
-                                ownerId
-                                // authentication.getId(),
-                                // authentication.getToken()
-                        )
-                ));
-    }
-
-    private Memo findMemoById(Long memoId) {
-        return memoRepository.findById(memoId)
-                .orElseThrow(() -> new NotFoundException(
-                        MessageFormat.format(
-                                "{} :: Memo Not Found. " +
-                                        "There does not exist a Memo with the given ID : {}",
-                                        // "\n\tRequested by a member(ID: {}, Token: {}",
-                                LocalDateTime.now(),
-                                memoId
-                                // authentication.getId(),
-                                // authentication.getToken()
-                        )
-                ));
-    }
-
-    private void validateScheduleMemo(Long scheduleId, Long memoId) {
-        boolean notExists = !memoRepository.existsByIdAndScheduleId(memoId, scheduleId);
-
-        if (notExists) {
-            throw new NotIncludeException(Schedule.class, Memo.class, scheduleId, memoId);
-        }
-    }
-
-
-    @Transactional
-    public void modifyMemo(Long scheduleId, Long memoId, MemoRequest memoRequest, Long memberId) {
-        Memo memo = findMemoById(memoId);
-
-        validateScheduleMemo(scheduleId, memoId);
-
-        validateMemoOwner(memo, memberId);
-
-        memo.modify(memoRequest.getTitle(), memoRequest.getContent());
-    }
-
-    private void validateMemoOwner(Memo memo, Long memberId) {
-        if (!memo.getMemberId().equals(memberId)) {
-            throw new ForbiddenException(Memo.class, memo.getId(), memberId);
-        }
-    }
-
-    @Transactional
-    public void deleteMemo(Long scheduleId, Long memoId, Long memberId) {
-        Memo memo = findMemoById(memoId);
-
-        validateScheduleMemo(scheduleId, memoId);
-
-        validateMemoOwner(memo, memberId);
-
-        memoRepository.delete(memo);
-    }
-
-    // 체크리스트
-    @Transactional
-    public Long saveChecklist(Long scheduleId, ChecklistCreationRequest checklistCreationRequest, Long memberId) {
-        Schedule schedule = findScheduleById(scheduleId);
-
-        validateScheduleMember(scheduleId, memberId);
-
-        Checklist checklist = createChecklist(checklistCreationRequest, schedule);
-
-        return checklistRepository.save(checklist).getId();
-    }
-
-    private Checklist createChecklist(ChecklistCreationRequest checklistCreationRequest, Schedule schedule) {
-        return Checklist.builder()
-                .title(checklistCreationRequest.getTitle())
-                .schedule(schedule)
-                .day(checklistCreationRequest.getDay())
-                .build();
-    }
-
-    @Transactional(readOnly = true)
-    public List<ChecklistResponse> getChecklists(Long scheduleId, Long memberId) {
-        validateScheduleMember(scheduleId, memberId);
-
-        return checklistRepository.findByScheduleId(scheduleId).stream()
-                .map(ChecklistResponse::from)
-                .collect(Collectors.toList());
-    }
-
-    @Transactional
-    public void doCheck(Long scheduleId, Long checklistId, Long memberId, boolean flag) {
-        Checklist checklist = findChecklistById(checklistId);
-
-        validateScheduleChecklist(scheduleId, checklistId);
-
-        validateScheduleMember(scheduleId, memberId);
-
-        checklist.check(flag);
-    }
-
-    private Checklist findChecklistById(Long checklistId) {
-        return checklistRepository.findById(checklistId)
-                .orElseThrow(() -> new NotFoundException(
-                        MessageFormat.format(
-                                "{} :: Checklist Not Found. " +
-                                        "There does not exist a Checklist with the given ID : {}",
-                                        // "\n\tRequested by a member(ID: {}, Token: {}",
-                                LocalDateTime.now(),
-                                checklistId
-                                // authentication.getId(),
-                                // authentication.getToken()
-                        )
-                ));
-    }
-
-    private void validateScheduleChecklist(Long scheduleId, Long checklistId) {
-        boolean notExists = !checklistRepository.existsByIdAndScheduleId(checklistId, scheduleId);
-
-        if (notExists) {
-            throw new NotIncludeException(Schedule.class, Checklist.class, scheduleId, checklistId);
-        }
-    }
-
-    @Transactional
-    public void deleteChecklist(Long scheduleId, Long checklistId, Long memberId) {
-        Checklist checklist = findChecklistById(checklistId);
-
-        validateScheduleChecklist(scheduleId, checklistId);
-
-        validateScheduleMember(scheduleId, memberId);
-
-        checklistRepository.delete(checklist);
-    }
-
-
-    // 투표
-    @Transactional
-    public Long saveVoting(Long scheduleId, VotingCreationRequest votingCreationRequest, Long memberId) {
-        Schedule schedule = findScheduleById(scheduleId);
-
-        validateScheduleMember(scheduleId, memberId);
-
-        Voting voting = createVoting(votingCreationRequest, memberId, schedule);
-
-        createVotingContents(votingCreationRequest, voting);
-
-        return votingRepository.save(voting).getId();
-    }
-
-    private Voting createVoting(VotingCreationRequest votingCreationRequest, Long memberId, Schedule schedule) {
-        return Voting.builder()
-                .schedule(schedule)
-                .title(votingCreationRequest.getTitle())
-                .multipleFlag(votingCreationRequest.isMultipleFlag())
-                .memberId(memberId)
-                .build();
-    }
-
-    private void createVotingContents(VotingCreationRequest votingCreationRequest, Voting voting) {
-        votingCreationRequest.getContents()
-                .forEach(content -> createVotingContent(voting, content));
-    }
-
-    private void createVotingContent(Voting voting, String votingContentName) {
-        VotingContent.builder()
-                .voting(voting)
-                .content(votingContentName)
-                .build();
-    }
-
-    private void validateScheduleVoting(Long scheduleId, Long votingId) {
-        boolean notExists = !votingRepository.existsByIdAndScheduleId(votingId, scheduleId);
-
-        if (notExists) {
-            throw new NotIncludeException(Schedule.class, Voting.class, scheduleId, votingId);
-        }
-    }
-
-    @Transactional(readOnly = true)
-    public List<VotingResponse> getVotingList(Long scheduleId, Long memberId) {
-        validateScheduleMember(scheduleId, memberId);
-
-        return votingRepository.findByScheduleId(scheduleId)
-                .stream()
-                .map(VotingResponse::from)
-                .collect(Collectors.toList());
-    }
-
-    @Transactional(readOnly = true)
-    public VotingResponse getVoting(Long scheduleId, Long votingId, Long memberId) {
-        Voting voting = findVotingById(votingId);
-
-        validateScheduleVoting(scheduleId, votingId);
-
-        validateScheduleMember(scheduleId, memberId);
-
-        Long ownerId = voting.getMemberId();
-
-        Member owner = findMemberById(ownerId);
-
-        return VotingResponse.of(voting, owner, memberId);
-    }
-
-    private Voting findVotingById(Long votingId) {
-        return votingRepository.findById(votingId)
-                .orElseThrow(() -> new NotFoundException(
-                        MessageFormat.format(
-                                "{} :: Voting Not Found. " +
-                                        "There does not exist a Voting with the given ID : {}",
-                                        // "\n\tRequested by a member(ID: {}, Token: {}",
-                                LocalDateTime.now(),
-                                votingId
-                                // authentication.getId(),
-                                // authentication.getToken()
-                        )
-                ));
-    }
-
-    @Transactional
-    public void doVote(Long scheduleId, Long votingId, VotingRequest votingRequest, Long memberId) {
-        Voting voting = findVotingById(votingId);
-
-        validateScheduleVoting(scheduleId, votingId);
-
-        validateScheduleMember(scheduleId, memberId);
-
-        voting.vote(votingRequest.getVotingMap(), memberId);
-    }
-
-    @Transactional
-    public void deleteVoting(Long scheduleId, Long votingId, Long memberId) {
-        Voting voting = findVotingById(votingId);
-
-        validateScheduleVoting(scheduleId, votingId);
-
-        validateVotingOwner(voting, memberId);
-
-        votingRepository.delete(voting);
-    }
-
-    private void validateVotingOwner(Voting voting, Long memberId) {
-        if (!voting.getMemberId().equals(memberId)) {
-            throw new ForbiddenException(Voting.class, voting.getId(), memberId);
-        }
-    }
-
-    // 여행 멤버
-    @Transactional
-    public void addScheduleMember(Long scheduleId, ScheduleMemberRequest scheduleMemberRequest, Long memberId) {
-        Schedule schedule = findScheduleById(scheduleId);
-
-        validateScheduleMember(scheduleId, memberId);
-
-        long friendId = scheduleMemberRequest.getFriendId();
-
-        validateFriends(friendId, memberId);
-
-        createScheduleMember(schedule, friendId);
-    }
-
-    private void createScheduleMember(Schedule schedule, long friendId) {
-        ScheduleMember.builder()
-                .memberId(friendId)
-                .schedule(schedule)
-                .build();
-    }
-
-    private void validateFriends(long friendId, Long memberId) {
-        friendRepository.findByFromIdAndToId(memberId, friendId)
-                .orElseThrow(() -> new NoFriendsException(friendId, memberId));
-    }
-
-    @Transactional(readOnly = true)
-    public List<MemberSimpleResponse> getScheduleMembers(Long scheduleId, Long memberId) {
-        Schedule schedule = findScheduleById(scheduleId);
-
-        validateScheduleMember(scheduleId, memberId);
-
-        List<Long> ids = schedule.getScheduleMembers().stream()
-                .map(ScheduleMember::getMemberId)
-                .collect(Collectors.toList());
-
-        return memberRepository.findByIdIn(ids)
-                .stream()
-                .map(MemberSimpleResponse::from)
-                .collect(Collectors.toList());
-    }
-
-    @Transactional
-    public void deleteScheduleMember(Long scheduleId, Long deletedId, Long memberId) {
-        Schedule schedule = findScheduleById(scheduleId);
-
-        validateScheduleMember(scheduleId, memberId);
-
-        if (isConstructor(schedule, deletedId)) {
-            throw new IllegalArgumentException(ExceptionMessageUtils.getMessage("exception.bad_request"));
-        }
-
-        ScheduleMember deletedMember = findDeletedMember(schedule, deletedId);
-
-        schedule.deleteScheduleMember(deletedMember);
-    }
-
-    private ScheduleMember findDeletedMember(Schedule schedule, Long deletedId) {
-        return schedule.getScheduleMembers().stream()
-                .filter(scheduleMember -> scheduleMember.getMemberId().equals(deletedId))
-                .findFirst()
-                .orElseThrow(
-                        () -> new IllegalArgumentException(
-                                ExceptionMessageUtils.getMessage("exception.bad_request")
-                        )
-                );
-    }
-
-    @Transactional
-    public void exitSchedule(Long scheduleId, Long memberId) {
-        Schedule schedule = findScheduleById(scheduleId);
-
-        validateScheduleMember(scheduleId, memberId);
-
-        if (memberId.equals(schedule.getMemberId())) {
-            scheduleRepository.delete(schedule);
-            return;
-        }
-
-        ScheduleMember deletedMember = findDeletedMember(schedule, memberId);
-
-        schedule.deleteScheduleMember(deletedMember);
     }
 }

--- a/src/main/java/com/cocodan/triplan/schedule/service/VotingService.java
+++ b/src/main/java/com/cocodan/triplan/schedule/service/VotingService.java
@@ -1,0 +1,137 @@
+package com.cocodan.triplan.schedule.service;
+
+import com.cocodan.triplan.exception.common.ForbiddenException;
+import com.cocodan.triplan.exception.common.NotFoundException;
+import com.cocodan.triplan.exception.common.NotIncludeException;
+import com.cocodan.triplan.member.domain.Member;
+import com.cocodan.triplan.member.service.MemberService;
+import com.cocodan.triplan.schedule.domain.Schedule;
+import com.cocodan.triplan.schedule.domain.Voting;
+import com.cocodan.triplan.schedule.domain.VotingContent;
+import com.cocodan.triplan.schedule.dto.request.VotingCreationRequest;
+import com.cocodan.triplan.schedule.dto.request.VotingRequest;
+import com.cocodan.triplan.schedule.dto.response.VotingResponse;
+import com.cocodan.triplan.schedule.repository.VotingRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.text.MessageFormat;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class VotingService {
+
+    private final VotingRepository votingRepository;
+
+    private final ScheduleService scheduleService;
+
+    private final MemberService memberService;
+
+    @Transactional
+    public Long saveVoting(Long scheduleId, VotingCreationRequest votingCreationRequest, Long memberId) {
+        Schedule schedule = scheduleService.findScheduleById(scheduleId);
+
+        scheduleService.validateScheduleMember(scheduleId, memberId);
+
+        Voting voting = createVoting(votingCreationRequest, memberId, schedule);
+
+        createVotingContents(votingCreationRequest, voting);
+
+        return votingRepository.save(voting).getId();
+    }
+
+    @Transactional(readOnly = true)
+    public List<VotingResponse> getVotingList(Long scheduleId, Long memberId) {
+        scheduleService.validateScheduleMember(scheduleId, memberId);
+
+        return votingRepository.findByScheduleId(scheduleId)
+                .stream()
+                .map(VotingResponse::from)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public VotingResponse getVoting(Long scheduleId, Long votingId, Long memberId) {
+        Voting voting = findVotingById(votingId);
+
+        validateScheduleVoting(scheduleId, votingId);
+
+        scheduleService.validateScheduleMember(scheduleId, memberId);
+
+        Long ownerId = voting.getMemberId();
+
+        Member owner = memberService.findMemberById(ownerId);
+
+        return VotingResponse.of(voting, owner, memberId);
+    }
+
+    @Transactional
+    public void doVote(Long scheduleId, Long votingId, VotingRequest votingRequest, Long memberId) {
+        Voting voting = findVotingById(votingId);
+
+        validateScheduleVoting(scheduleId, votingId);
+
+        scheduleService.validateScheduleMember(scheduleId, memberId);
+
+        voting.vote(votingRequest.getVotingMap(), memberId);
+    }
+
+    @Transactional
+    public void deleteVoting(Long scheduleId, Long votingId, Long memberId) {
+        Voting voting = findVotingById(votingId);
+
+        validateScheduleVoting(scheduleId, votingId);
+
+        validateVotingOwner(voting, memberId);
+
+        votingRepository.delete(voting);
+    }
+
+    private Voting createVoting(VotingCreationRequest votingCreationRequest, Long memberId, Schedule schedule) {
+        return Voting.builder()
+                .schedule(schedule)
+                .title(votingCreationRequest.getTitle())
+                .multipleFlag(votingCreationRequest.isMultipleFlag())
+                .memberId(memberId)
+                .build();
+    }
+
+    private void createVotingContents(VotingCreationRequest votingCreationRequest, Voting voting) {
+        votingCreationRequest.getContents()
+                .forEach(content -> createVotingContent(voting, content));
+    }
+
+    private void createVotingContent(Voting voting, String votingContentName) {
+        VotingContent.builder()
+                .voting(voting)
+                .content(votingContentName)
+                .build();
+    }
+
+    private void validateScheduleVoting(Long scheduleId, Long votingId) {
+        boolean notExists = !votingRepository.existsByIdAndScheduleId(votingId, scheduleId);
+
+        if (notExists) {
+            throw new NotIncludeException(Schedule.class, Voting.class, scheduleId, votingId);
+        }
+    }
+
+    private Voting findVotingById(Long votingId) {
+        return votingRepository.findById(votingId)
+                .orElseThrow(() -> new NotFoundException(MessageFormat.format(
+                        "{} :: Voting Not Found. " +
+                                "There does not exist a Voting with the given ID : {}",
+                        LocalDateTime.now(), votingId
+                )));
+    }
+
+    private void validateVotingOwner(Voting voting, Long memberId) {
+        if (!voting.getMemberId().equals(memberId)) {
+            throw new ForbiddenException(Voting.class, voting.getId(), memberId);
+        }
+    }
+}

--- a/src/test/java/com/cocodan/triplan/schedule/service/ChecklistServiceTest.java
+++ b/src/test/java/com/cocodan/triplan/schedule/service/ChecklistServiceTest.java
@@ -1,0 +1,100 @@
+package com.cocodan.triplan.schedule.service;
+
+import com.cocodan.triplan.member.dto.response.MemberCreateResponse;
+import com.cocodan.triplan.member.service.MemberService;
+import com.cocodan.triplan.schedule.domain.Checklist;
+import com.cocodan.triplan.schedule.dto.request.ChecklistCreationRequest;
+import com.cocodan.triplan.schedule.repository.ChecklistRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.annotation.PostConstruct;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+public class ChecklistServiceTest {
+
+    private Long MEMBER_ID;
+
+    @Autowired
+    private ChecklistService checklistService;
+
+    @Autowired
+    private ChecklistRepository checklistRepository;
+
+    @Autowired
+    private ScheduleService scheduleService;
+
+    @Autowired
+    private MemberService memberService;
+
+    @PostConstruct
+    void postConstruct() {
+        MemberCreateResponse memberCreateResponse = memberService.create(
+                "ffff@naver.com",
+                "taehyun",
+                "1994-12-16",
+                "MALE",
+                "henry",
+                "",
+                "asdf123",
+                1L);
+        MEMBER_ID = memberCreateResponse.getId();
+    }
+
+    @Test
+    @DisplayName("체크리스트를 추가한다")
+    void createChecklist() {
+        // Given
+        Long schedule = scheduleService.saveSchedule(TestDataFactory.createScheduleCreation(), MEMBER_ID);
+        ChecklistCreationRequest checklistCreationRequest = new ChecklistCreationRequest(0, "밥 먹을 사람");
+
+        // When
+        Long checklist = checklistService.saveChecklist(schedule, checklistCreationRequest, MEMBER_ID);
+
+        // Then
+        assertThat(checklist).isEqualTo(1L);
+    }
+
+    @DisplayName("체크리스트 선택 및 해제")
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void doCheck(boolean flag) {
+        // Given
+        Long schedule = scheduleService.saveSchedule(TestDataFactory.createScheduleCreation(), MEMBER_ID);
+        ChecklistCreationRequest checklistCreationRequest = new ChecklistCreationRequest(1, "밥 먹을 사람");
+        Long checklist = checklistService.saveChecklist(schedule, checklistCreationRequest, MEMBER_ID);
+
+        // When
+        checklistService.doCheck(schedule, checklist, MEMBER_ID, flag);
+        Checklist saved = checklistRepository.findById(checklist).get();
+
+        // Then
+        assertThat(saved.isChecked()).isEqualTo(flag);
+    }
+
+    @Test
+    @DisplayName("체크리스트를 삭제한다")
+    void deleteChecklist() {
+        // Given
+        Long schedule = scheduleService.saveSchedule(TestDataFactory.createScheduleCreation(), MEMBER_ID);
+        ChecklistCreationRequest checklistCreationRequest = new ChecklistCreationRequest(1, "밥 먹을 사람");
+        Long checklist = checklistService.saveChecklist(schedule, checklistCreationRequest, MEMBER_ID);
+
+        // When
+        checklistService.deleteChecklist(schedule, checklist, MEMBER_ID);
+        Optional<Checklist> saved = checklistRepository.findById(checklist);
+
+        // Then
+        assertThat(saved).isEqualTo(Optional.empty());
+    }
+
+}

--- a/src/test/java/com/cocodan/triplan/schedule/service/MemoServiceTest.java
+++ b/src/test/java/com/cocodan/triplan/schedule/service/MemoServiceTest.java
@@ -1,0 +1,157 @@
+package com.cocodan.triplan.schedule.service;
+
+import com.cocodan.triplan.member.dto.response.MemberCreateResponse;
+import com.cocodan.triplan.member.service.MemberService;
+import com.cocodan.triplan.schedule.domain.Memo;
+import com.cocodan.triplan.schedule.dto.request.MemoRequest;
+import com.cocodan.triplan.schedule.dto.response.MemoResponse;
+import com.cocodan.triplan.schedule.repository.MemoRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.annotation.PostConstruct;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+public class MemoServiceTest {
+
+    private Long MEMBER_ID;
+
+    @Autowired
+    private ScheduleService scheduleService;
+
+    @Autowired
+    private MemoService memoService;
+
+    @Autowired
+    private MemoRepository memoRepository;
+
+    @Autowired
+    private MemberService memberService;
+
+    @PostConstruct
+    void postConstruct() {
+        MemberCreateResponse memberCreateResponse = memberService.create(
+                "ffff@naver.com",
+                "taehyun",
+                "1994-12-16",
+                "MALE",
+                "henry",
+                "",
+                "asdf123",
+                1L);
+        MEMBER_ID = memberCreateResponse.getId();
+    }
+
+    @Test
+    @DisplayName("메모를 추가한다")
+    void createMemo() {
+        // Given
+        Long schedule = scheduleService.saveSchedule(TestDataFactory.createScheduleCreation(), MEMBER_ID);
+        MemoRequest memoRequest = new MemoRequest("memotitle", "JIFEOgoiioghiohgieogio");
+
+        // When
+        Long memo = memoService.saveMemo(schedule, memoRequest, MEMBER_ID);
+
+        Memo actual = memoRepository.findById(memo).get();
+
+        // Then
+        assertThat(actual.getTitle()).isEqualTo("memotitle");
+        assertThat(actual.getContent()).isEqualTo("JIFEOgoiioghiohgieogio");
+    }
+
+    @Test
+    @DisplayName("메모 목록을 조회한다")
+    void getMemos() {
+        // Given
+        Long schedule = scheduleService.saveSchedule(TestDataFactory.createScheduleCreation(), MEMBER_ID);
+        MemoRequest memoRequest1 = new MemoRequest("memotitle1", "JIFEOgoiioghiohgieogio1");
+        MemoRequest memoRequest2 = new MemoRequest("memotitle2", "JIFEOgoiioghiohgieogio2");
+        MemoRequest memoRequest3 = new MemoRequest("memotitle3", "JIFEOgoiioghiohgieogio3");
+
+        Long memo1 = memoService.saveMemo(schedule, memoRequest1, MEMBER_ID);
+        Long memo2 = memoService.saveMemo(schedule, memoRequest2, MEMBER_ID);
+        Long memo3 = memoService.saveMemo(schedule, memoRequest3, MEMBER_ID);
+
+        // When
+        List<MemoResponse> memos = memoService.getMemos(schedule, MEMBER_ID);
+
+        List<String> titles = memos.stream()
+                .map(MemoResponse::getTitle)
+                .collect(Collectors.toList());
+
+        List<String> contents = memos.stream()
+                .map((MemoResponse::getContent))
+                .collect(Collectors.toList());
+
+        List<Long> ids = memos.stream()
+                .map((MemoResponse::getId))
+                .collect(Collectors.toList());
+
+
+        // Then
+        assertThat(ids).containsExactly(memo1, memo2, memo3);
+        assertThat(titles).containsExactlyInAnyOrder("memotitle1", "memotitle2", "memotitle3");
+        assertThat(contents).containsExactlyInAnyOrder("JIFEOgoiioghiohgieogio1", "JIFEOgoiioghiohgieogio2", "JIFEOgoiioghiohgieogio3");
+    }
+
+    @Test
+    @DisplayName("메모를 상세 조회 한다")
+    void getMemo() {
+        // Given
+        Long schedule = scheduleService.saveSchedule(TestDataFactory.createScheduleCreation(), MEMBER_ID);
+        MemoRequest memoRequest1 = new MemoRequest("memotitle1", "JIFEOgoiioghiohgieogio1");
+        Long memo = memoService.saveMemo(schedule, memoRequest1, MEMBER_ID);
+
+        // When
+        MemoResponse actual = memoService.getMemo(schedule, memo, MEMBER_ID);
+
+        // Then
+        assertThat(actual.getTitle()).isEqualTo("memotitle1");
+        assertThat(actual.getContent()).isEqualTo("JIFEOgoiioghiohgieogio1");
+        assertThat(actual.getMemberSimpleResponse().getId()).isEqualTo(MEMBER_ID);
+    }
+
+    @Test
+    @DisplayName("메모를 수정한다")
+    void modifyMemo() {
+        // Given
+        Long schedule = scheduleService.saveSchedule(TestDataFactory.createScheduleCreation(), MEMBER_ID);
+        MemoRequest memoRequest = new MemoRequest("memotitle", "JIFEOgoiioghiohgieogio");
+        Long memo = memoService.saveMemo(schedule, memoRequest, MEMBER_ID);
+
+        // When
+        MemoRequest updateRequest = new MemoRequest("핫둘셋넷다여일여아열핫둘셋넷닷엿", "Updated Memo Content");
+        memoService.modifyMemo(schedule, memo, updateRequest, MEMBER_ID);
+
+        // Then
+        Memo updated = memoRepository.findById(memo).get();
+        assertThat(updated.getContent()).isEqualTo(updateRequest.getContent());
+        assertThat(updated.getTitle()).isEqualTo(updateRequest.getTitle());
+    }
+
+    @Test
+    @DisplayName("메모를 삭제한다")
+    void deleteMemo() {
+        // Given
+        Long schedule = scheduleService.saveSchedule(TestDataFactory.createScheduleCreation(), MEMBER_ID);
+        MemoRequest memoRequest = new MemoRequest("memotitle", "JIFEOgoiioghiohgieogio");
+        Long memo = memoService.saveMemo(schedule, memoRequest, MEMBER_ID);
+
+        // When
+        memoService.deleteMemo(schedule, memo, MEMBER_ID);
+
+        // Then
+        Optional<Memo> optionalMemo = memoRepository.findById(memo);
+        assertThat(optionalMemo).isEqualTo(Optional.empty());
+    }
+
+}

--- a/src/test/java/com/cocodan/triplan/schedule/service/ScheduleMemberServiceTest.java
+++ b/src/test/java/com/cocodan/triplan/schedule/service/ScheduleMemberServiceTest.java
@@ -1,0 +1,24 @@
+package com.cocodan.triplan.schedule.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+public class ScheduleMemberServiceTest {
+
+    @Autowired
+    private ScheduleMemberService scheduleMemberService;
+
+    @Autowired
+    private ScheduleService scheduleService;
+
+    //여행멤버 추가하기
+
+    // 여행멤버 리스트 조회하기
+
+    // 여행멤버 삭제하기
+
+    // 여행에서 나가기
+}

--- a/src/test/java/com/cocodan/triplan/schedule/service/ScheduleServiceTest.java
+++ b/src/test/java/com/cocodan/triplan/schedule/service/ScheduleServiceTest.java
@@ -41,15 +41,6 @@ class ScheduleServiceTest {
     private ScheduleRepository scheduleRepository;
 
     @Autowired
-    private MemoRepository memoRepository;
-
-    @Autowired
-    private ChecklistRepository checklistRepository;
-
-    @Autowired
-    private VotingRepository votingRepository;
-
-    @Autowired
     private MemberService memberService;
 
     @PostConstruct
@@ -70,7 +61,7 @@ class ScheduleServiceTest {
     @DisplayName("여행 일정을 생성한다.")
     void createSchedule() {
         // Given
-        ScheduleCreationRequest scheduleCreationRequest = createScheduleCreation();
+        ScheduleCreationRequest scheduleCreationRequest = TestDataFactory.createScheduleCreation();
 
         // When
         Long scheduleId = scheduleService.saveSchedule(scheduleCreationRequest, MEMBER_ID);
@@ -82,25 +73,11 @@ class ScheduleServiceTest {
         assertThat(schedule.getCreatedDate()).isNotNull();
     }
 
-    private ScheduleCreationRequest createScheduleCreation() {
-        return new ScheduleCreationRequest("title", LocalDate.of(2021, 12, 1), LocalDate.of(2021, 12, 3), List.of("activity", "food"),
-                List.of(new DailyScheduleSpotCreationRequest(11L, "address1", "roadAddress1", "010-1111-2222", "불국사1", new Position(37.1234, 125.3333), 1, 1),
-                        new DailyScheduleSpotCreationRequest(21L, "address2", "roadAddress2", "010-1111-2223", "불국사2", new Position(37.1234, 125.3333), 1, 2),
-                        new DailyScheduleSpotCreationRequest(31L, "address3", "roadAddress3", "010-1111-2224", "불국사3", new Position(37.1234, 125.3333), 1, 3),
-                        new DailyScheduleSpotCreationRequest(41L, "address4", "roadAddress4", "010-1111-2225", "불국사4", new Position(37.1234, 125.3333), 2, 1),
-                        new DailyScheduleSpotCreationRequest(51L, "address5", "roadAddress5", "010-1111-2226", "불국사5", new Position(37.1234, 125.3333), 2, 2),
-                        new DailyScheduleSpotCreationRequest(61L, "address6", "roadAddress6", "010-1111-2227", "불국사6", new Position(37.1234, 125.3333), 2, 3),
-                        new DailyScheduleSpotCreationRequest(71L, "address7", "roadAddress7", "010-1111-2228", "불국사7", new Position(37.1234, 125.3333), 3, 1),
-                        new DailyScheduleSpotCreationRequest(81L, "address8", "roadAddress8", "010-1111-2229", "불국사8", new Position(37.1234, 125.3333), 3, 2)
-                ),
-                List.of());
-    }
-
     @Test
     @DisplayName("일정 목록을 조회한다.")
     void getSchedules() {
         // Given
-        ScheduleCreationRequest scheduleCreationRequest = createScheduleCreation();
+        ScheduleCreationRequest scheduleCreationRequest = TestDataFactory.createScheduleCreation();
         Long scheduleId = scheduleService.saveSchedule(scheduleCreationRequest, MEMBER_ID);
 
         // When
@@ -119,7 +96,7 @@ class ScheduleServiceTest {
     @DisplayName("일정을 상세 조회한다.")
     void getSchedule() {
         // Given
-        ScheduleCreationRequest scheduleCreationRequest = createScheduleCreation();
+        ScheduleCreationRequest scheduleCreationRequest = TestDataFactory.createScheduleCreation();
         Long scheduleId = scheduleService.saveSchedule(scheduleCreationRequest, MEMBER_ID);
 
         // When
@@ -154,7 +131,7 @@ class ScheduleServiceTest {
     @DisplayName("일정 장소 리스트를 수정한다")
     void modifySpots() {
         // Given
-        ScheduleCreationRequest scheduleCreationRequest = createScheduleCreation();
+        ScheduleCreationRequest scheduleCreationRequest = TestDataFactory.createScheduleCreation();
         Long schedule = scheduleService.saveSchedule(scheduleCreationRequest, MEMBER_ID);
 
         ScheduleModificationRequest scheduleModificationRequest = new ScheduleModificationRequest("updated Title", List.of("NATURE"),
@@ -185,7 +162,7 @@ class ScheduleServiceTest {
     @DisplayName("일정을 삭제한다")
     void deleteSchedule() {
         // Given
-        ScheduleCreationRequest scheduleCreationRequest = createScheduleCreation();
+        ScheduleCreationRequest scheduleCreationRequest = TestDataFactory.createScheduleCreation();
         Long schedule = scheduleService.saveSchedule(scheduleCreationRequest, MEMBER_ID);
 
         // When
@@ -193,291 +170,5 @@ class ScheduleServiceTest {
 
         // Then
         assertThat(scheduleRepository.findById(schedule)).isNotPresent();
-    }
-
-    @Test
-    @DisplayName("메모를 추가한다")
-    void createMemo() {
-        // Given
-        Long schedule = scheduleService.saveSchedule(createScheduleCreation(), MEMBER_ID);
-        MemoRequest memoRequest = new MemoRequest("memotitle", "JIFEOgoiioghiohgieogio");
-
-        // When
-        Long memo = scheduleService.saveMemo(schedule, memoRequest, MEMBER_ID);
-
-        Memo actual = memoRepository.findById(memo).get();
-
-        // Then
-        assertThat(actual.getTitle()).isEqualTo("memotitle");
-        assertThat(actual.getContent()).isEqualTo("JIFEOgoiioghiohgieogio");
-    }
-
-    @Test
-    @DisplayName("메모 목록을 조회한다")
-    void getMemos() {
-        // Given
-        Long schedule = scheduleService.saveSchedule(createScheduleCreation(), MEMBER_ID);
-        MemoRequest memoRequest1 = new MemoRequest("memotitle1", "JIFEOgoiioghiohgieogio1");
-        MemoRequest memoRequest2 = new MemoRequest("memotitle2", "JIFEOgoiioghiohgieogio2");
-        MemoRequest memoRequest3 = new MemoRequest("memotitle3", "JIFEOgoiioghiohgieogio3");
-
-        Long memo1 = scheduleService.saveMemo(schedule, memoRequest1, MEMBER_ID);
-        Long memo2 = scheduleService.saveMemo(schedule, memoRequest2, MEMBER_ID);
-        Long memo3 = scheduleService.saveMemo(schedule, memoRequest3, MEMBER_ID);
-
-        // When
-        List<MemoResponse> memos = scheduleService.getMemos(schedule, MEMBER_ID);
-
-        List<String> titles = memos.stream()
-                .map(MemoResponse::getTitle)
-                .collect(Collectors.toList());
-
-        List<String> contents = memos.stream()
-                .map((MemoResponse::getContent))
-                .collect(Collectors.toList());
-
-        List<Long> ids = memos.stream()
-                .map((MemoResponse::getId))
-                .collect(Collectors.toList());
-
-
-        // Then
-        assertThat(ids).containsExactly(memo1, memo2, memo3);
-        assertThat(titles).containsExactlyInAnyOrder("memotitle1", "memotitle2", "memotitle3");
-        assertThat(contents).containsExactlyInAnyOrder("JIFEOgoiioghiohgieogio1", "JIFEOgoiioghiohgieogio2", "JIFEOgoiioghiohgieogio3");
-    }
-
-    @Test
-    @DisplayName("메모를 상세 조회 한다")
-    void getMemo() {
-        // Given
-        Long schedule = scheduleService.saveSchedule(createScheduleCreation(), MEMBER_ID);
-        MemoRequest memoRequest1 = new MemoRequest("memotitle1", "JIFEOgoiioghiohgieogio1");
-        Long memo = scheduleService.saveMemo(schedule, memoRequest1, MEMBER_ID);
-
-        // When
-        MemoResponse actual = scheduleService.getMemo(schedule, memo, MEMBER_ID);
-
-        // Then
-        assertThat(actual.getTitle()).isEqualTo("memotitle1");
-        assertThat(actual.getContent()).isEqualTo("JIFEOgoiioghiohgieogio1");
-        assertThat(actual.getMemberSimpleResponse().getId()).isEqualTo(MEMBER_ID);
-    }
-
-    @Test
-    @DisplayName("메모를 수정한다")
-    void modifyMemo() {
-        // Given
-        Long schedule = scheduleService.saveSchedule(createScheduleCreation(), MEMBER_ID);
-        MemoRequest memoRequest = new MemoRequest("memotitle", "JIFEOgoiioghiohgieogio");
-        Long memo = scheduleService.saveMemo(schedule, memoRequest, MEMBER_ID);
-
-        // When
-        MemoRequest updateRequest = new MemoRequest("핫둘셋넷다여일여아열핫둘셋넷닷엿", "Updated Memo Content");
-        scheduleService.modifyMemo(schedule, memo, updateRequest, MEMBER_ID);
-
-        // Then
-        Memo updated = memoRepository.findById(memo).get();
-        assertThat(updated.getContent()).isEqualTo(updateRequest.getContent());
-        assertThat(updated.getTitle()).isEqualTo(updateRequest.getTitle());
-    }
-
-    @Test
-    @DisplayName("메모를 삭제한다")
-    void deleteMemo() {
-        // Given
-        Long schedule = scheduleService.saveSchedule(createScheduleCreation(), MEMBER_ID);
-        MemoRequest memoRequest = new MemoRequest("memotitle", "JIFEOgoiioghiohgieogio");
-        Long memo = scheduleService.saveMemo(schedule, memoRequest, MEMBER_ID);
-
-        // When
-        scheduleService.deleteMemo(schedule, memo, MEMBER_ID);
-
-        // Then
-        Optional<Memo> optionalMemo = memoRepository.findById(memo);
-        assertThat(optionalMemo).isEqualTo(Optional.empty());
-    }
-
-    @Test
-    @DisplayName("체크리스트를 추가한다")
-    void createChecklist() {
-        // Given
-        Long schedule = scheduleService.saveSchedule(createScheduleCreation(), MEMBER_ID);
-        ChecklistCreationRequest checklistCreationRequest = new ChecklistCreationRequest(0, "밥 먹을 사람");
-
-        // When
-        Long checklist = scheduleService.saveChecklist(schedule, checklistCreationRequest, MEMBER_ID);
-
-        // Then
-        assertThat(checklist).isEqualTo(1L);
-    }
-
-    @DisplayName("체크리스트 선택 및 해제")
-    @ParameterizedTest
-    @ValueSource(booleans = {true, false})
-    void doCheck(boolean flag) {
-        // Given
-        Long schedule = scheduleService.saveSchedule(createScheduleCreation(), MEMBER_ID);
-        ChecklistCreationRequest checklistCreationRequest = new ChecklistCreationRequest(1, "밥 먹을 사람");
-        Long checklist = scheduleService.saveChecklist(schedule, checklistCreationRequest, MEMBER_ID);
-
-        // When
-        scheduleService.doCheck(schedule, checklist, MEMBER_ID, flag);
-        Checklist saved = checklistRepository.findById(checklist).get();
-
-        // Then
-        assertThat(saved.isChecked()).isEqualTo(flag);
-    }
-
-    @Test
-    @DisplayName("체크리스트를 삭제한다")
-    void deleteChecklist() {
-        // Given
-        Long schedule = scheduleService.saveSchedule(createScheduleCreation(), MEMBER_ID);
-        ChecklistCreationRequest checklistCreationRequest = new ChecklistCreationRequest(1, "밥 먹을 사람");
-        Long checklist = scheduleService.saveChecklist(schedule, checklistCreationRequest, MEMBER_ID);
-
-        // When
-        scheduleService.deleteChecklist(schedule, checklist, MEMBER_ID);
-        Optional<Checklist> saved = checklistRepository.findById(checklist);
-
-        // Then
-        assertThat(saved).isEqualTo(Optional.empty());
-    }
-
-    @Test
-    @DisplayName("투표를 추가한다")
-    void createVoting() {
-        // Given
-        Long schedule = scheduleService.saveSchedule(createScheduleCreation(), MEMBER_ID);
-        VotingCreationRequest votingCreationRequest = new VotingCreationRequest("무슨 요일날 갈까요?", List.of("월", "화", "수", "목"), false);
-
-        // When
-        Long voting = scheduleService.saveVoting(schedule, votingCreationRequest, MEMBER_ID);
-        Voting savedVoting = votingRepository.findById(voting).get();
-
-
-        List<String> contentList = savedVoting.getVotingContents()
-                .stream()
-                .map(votingContent -> votingContent.getContent())
-                .collect(Collectors.toList());
-
-        // Then
-        assertThat(savedVoting.getTitle()).isEqualTo("무슨 요일날 갈까요?");
-        assertThat(savedVoting.isMultipleFlag()).isFalse();
-        assertThat(contentList).containsExactly("월", "화", "수", "목");
-    }
-
-    @Test
-    @DisplayName("투표 목록을 조회한다")
-    void getVotings() {
-        // Given
-        Long schedule = scheduleService.saveSchedule(createScheduleCreation(), MEMBER_ID);
-        VotingCreationRequest votingCreationRequest1 = new VotingCreationRequest("무슨 요일날 갈까요?", List.of("월", "화", "수", "목"), false);
-        VotingCreationRequest votingCreationRequest2 = new VotingCreationRequest("어디 여행 갈래", List.of("서울", "부산", "제주도", "안 가"), true);
-
-        Long voting1 = scheduleService.saveVoting(schedule, votingCreationRequest1, MEMBER_ID);
-        Long voting2 = scheduleService.saveVoting(schedule, votingCreationRequest2, MEMBER_ID);
-
-        // When
-        List<VotingResponse> votingList = scheduleService.getVotingList(schedule, MEMBER_ID);
-
-        List<String> titles = votingList.stream()
-                .map(VotingResponse::getTitle)
-                .collect(Collectors.toList());
-
-        List<Integer> counts = votingList.stream()
-                .map(VotingResponse::getNumOfTotalParticipants)
-                .collect(Collectors.toList());
-
-        // Then
-        assertThat(titles).contains("무슨 요일날 갈까요?", "어디 여행 갈래");
-        assertThat(counts).containsExactly(0, 0);
-    }
-
-    @Test
-    @DisplayName("투표의 상세 정보를 조회한다")
-    void getVoting() {
-        // Given
-        Long schedule = scheduleService.saveSchedule(createScheduleCreation(), MEMBER_ID);
-        VotingCreationRequest votingCreationRequest = new VotingCreationRequest("무슨 요일날 갈까요?", List.of("월", "화", "수", "목"), false);
-
-        Long voting = scheduleService.saveVoting(schedule, votingCreationRequest, MEMBER_ID);
-
-        // When
-        VotingResponse response = scheduleService.getVoting(schedule, voting, MEMBER_ID);
-
-        List<String> contents = response.getVotingContentResponses().stream()
-                .map(VotingContentResponse::getContent)
-                .collect(Collectors.toList());
-
-        // Then
-        assertThat(response.getId()).isEqualTo(voting);
-        assertThat(response.getTitle()).isEqualTo("무슨 요일날 갈까요?");
-        assertThat(response.getNumOfTotalParticipants()).isZero();
-        assertThat(response.getMemberSimpleResponse().getId()).isEqualTo(MEMBER_ID);
-        assertThat(contents).containsExactly("월", "화", "수", "목");
-    }
-
-    @Test
-    @DisplayName("투표를 행사 한다")
-    void vote() {
-        // Given
-        Long schedule = scheduleService.saveSchedule(createScheduleCreation(), MEMBER_ID);
-        VotingCreationRequest votingCreationRequest = new VotingCreationRequest("무슨 요일날 갈까요?", List.of("월", "화", "수", "목"), false);
-
-        Long voting = scheduleService.saveVoting(schedule, votingCreationRequest, MEMBER_ID);
-        Voting saved = votingRepository.findById(voting).get();
-
-        List<Long> ids = saved.getVotingContents().stream()
-                .map(VotingContent::getId)
-                .collect(Collectors.toList());
-
-        Map<Long, Boolean> votingMap = Map.of(ids.get(0), true, ids.get(1), false, ids.get(2), false, ids.get(3), false);
-        VotingRequest votingRequest = new VotingRequest(votingMap);
-
-        // When
-        scheduleService.doVote(schedule, voting, votingRequest, MEMBER_ID);
-
-        List<VotingContent> votingContents = saved.getVotingContents();
-
-        List<Integer> votingCountList = votingContents.stream()
-                .map(VotingContent::getNumOfParticipants)
-                .collect(Collectors.toList());
-
-        // Then
-        votingContents.forEach(votingContent -> {
-            if (votingMap.get(votingContent.getId())) {
-                assertThat(getVotingMemberIds(votingContent)).contains(MEMBER_ID);
-            } else {
-                assertThat(getVotingMemberIds(votingContent)).doesNotContain(MEMBER_ID);
-            }
-        });
-
-        assertThat(votingCountList).containsExactly(1, 0, 0, 0);
-        assertThat(saved.getNumOfTotalParticipants()).isEqualTo(1);
-    }
-
-    private List<Long> getVotingMemberIds(VotingContent votingContent) {
-        return votingContent.getVotingContentMembers()
-                .stream()
-                .map(VotingContentMember::getMemberId)
-                .collect(Collectors.toList());
-    }
-
-    @Test
-    @DisplayName("투표를 삭제한다")
-    void deleteVoting() {
-        // Given
-        Long schedule = scheduleService.saveSchedule(createScheduleCreation(), MEMBER_ID);
-        VotingCreationRequest votingCreationRequest = new VotingCreationRequest("무슨 요일날 갈까요?", List.of("월", "화", "수", "목"), false);
-        Long voting = scheduleService.saveVoting(schedule, votingCreationRequest, MEMBER_ID);
-
-        // When
-        scheduleService.deleteVoting(schedule, voting, MEMBER_ID);
-        Optional<Voting> actual = votingRepository.findById(voting);
-
-        // Then
-        assertThat(actual).isNotPresent();
     }
 }

--- a/src/test/java/com/cocodan/triplan/schedule/service/TestDataFactory.java
+++ b/src/test/java/com/cocodan/triplan/schedule/service/TestDataFactory.java
@@ -1,0 +1,27 @@
+package com.cocodan.triplan.schedule.service;
+
+import com.cocodan.triplan.schedule.dto.request.DailyScheduleSpotCreationRequest;
+import com.cocodan.triplan.schedule.dto.request.Position;
+import com.cocodan.triplan.schedule.dto.request.ScheduleCreationRequest;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public class TestDataFactory {
+
+    public static ScheduleCreationRequest createScheduleCreation() {
+        return new ScheduleCreationRequest("title", LocalDate.of(2021, 12, 1), LocalDate.of(2021, 12, 3), List.of("activity", "food"),
+                List.of(new DailyScheduleSpotCreationRequest(11L, "address1", "roadAddress1", "010-1111-2222", "불국사1", new Position(37.1234, 125.3333), 1, 1),
+                        new DailyScheduleSpotCreationRequest(21L, "address2", "roadAddress2", "010-1111-2223", "불국사2", new Position(37.1234, 125.3333), 1, 2),
+                        new DailyScheduleSpotCreationRequest(31L, "address3", "roadAddress3", "010-1111-2224", "불국사3", new Position(37.1234, 125.3333), 1, 3),
+                        new DailyScheduleSpotCreationRequest(41L, "address4", "roadAddress4", "010-1111-2225", "불국사4", new Position(37.1234, 125.3333), 2, 1),
+                        new DailyScheduleSpotCreationRequest(51L, "address5", "roadAddress5", "010-1111-2226", "불국사5", new Position(37.1234, 125.3333), 2, 2),
+                        new DailyScheduleSpotCreationRequest(61L, "address6", "roadAddress6", "010-1111-2227", "불국사6", new Position(37.1234, 125.3333), 2, 3),
+                        new DailyScheduleSpotCreationRequest(71L, "address7", "roadAddress7", "010-1111-2228", "불국사7", new Position(37.1234, 125.3333), 3, 1),
+                        new DailyScheduleSpotCreationRequest(81L, "address8", "roadAddress8", "010-1111-2229", "불국사8", new Position(37.1234, 125.3333), 3, 2)
+                ),
+                List.of());
+    }
+
+
+}

--- a/src/test/java/com/cocodan/triplan/schedule/service/VotingServiceTest.java
+++ b/src/test/java/com/cocodan/triplan/schedule/service/VotingServiceTest.java
@@ -1,0 +1,194 @@
+package com.cocodan.triplan.schedule.service;
+
+import com.cocodan.triplan.member.dto.response.MemberCreateResponse;
+import com.cocodan.triplan.member.service.MemberService;
+import com.cocodan.triplan.schedule.domain.Voting;
+import com.cocodan.triplan.schedule.domain.VotingContent;
+import com.cocodan.triplan.schedule.domain.VotingContentMember;
+import com.cocodan.triplan.schedule.dto.request.VotingCreationRequest;
+import com.cocodan.triplan.schedule.dto.request.VotingRequest;
+import com.cocodan.triplan.schedule.dto.response.VotingContentResponse;
+import com.cocodan.triplan.schedule.dto.response.VotingResponse;
+import com.cocodan.triplan.schedule.repository.VotingRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.annotation.PostConstruct;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+public class VotingServiceTest {
+
+    private Long MEMBER_ID;
+
+    @Autowired
+    private VotingService votingService;
+
+    @Autowired
+    private VotingRepository votingRepository;
+
+    @Autowired
+    private ScheduleService scheduleService;
+
+    @Autowired
+    private MemberService memberService;
+
+    @PostConstruct
+    void postConstruct() {
+        MemberCreateResponse memberCreateResponse = memberService.create(
+                "ffff@naver.com",
+                "taehyun",
+                "1994-12-16",
+                "MALE",
+                "henry",
+                "",
+                "asdf123",
+                1L);
+        MEMBER_ID = memberCreateResponse.getId();
+    }
+
+    @Test
+    @DisplayName("투표를 추가한다")
+    void createVoting() {
+        // Given
+        Long schedule = scheduleService.saveSchedule(TestDataFactory.createScheduleCreation(), MEMBER_ID);
+        VotingCreationRequest votingCreationRequest = new VotingCreationRequest("무슨 요일날 갈까요?", List.of("월", "화", "수", "목"), false);
+
+        // When
+        Long voting = votingService.saveVoting(schedule, votingCreationRequest, MEMBER_ID);
+        Voting savedVoting = votingRepository.findById(voting).get();
+
+
+        List<String> contentList = savedVoting.getVotingContents()
+                .stream()
+                .map(votingContent -> votingContent.getContent())
+                .collect(Collectors.toList());
+
+        // Then
+        assertThat(savedVoting.getTitle()).isEqualTo("무슨 요일날 갈까요?");
+        assertThat(savedVoting.isMultipleFlag()).isFalse();
+        assertThat(contentList).containsExactly("월", "화", "수", "목");
+    }
+
+    @Test
+    @DisplayName("투표 목록을 조회한다")
+    void getVotings() {
+        // Given
+        Long schedule = scheduleService.saveSchedule(TestDataFactory.createScheduleCreation(), MEMBER_ID);
+        VotingCreationRequest votingCreationRequest1 = new VotingCreationRequest("무슨 요일날 갈까요?", List.of("월", "화", "수", "목"), false);
+        VotingCreationRequest votingCreationRequest2 = new VotingCreationRequest("어디 여행 갈래", List.of("서울", "부산", "제주도", "안 가"), true);
+
+        Long voting1 = votingService.saveVoting(schedule, votingCreationRequest1, MEMBER_ID);
+        Long voting2 = votingService.saveVoting(schedule, votingCreationRequest2, MEMBER_ID);
+
+        // When
+        List<VotingResponse> votingList = votingService.getVotingList(schedule, MEMBER_ID);
+
+        List<String> titles = votingList.stream()
+                .map(VotingResponse::getTitle)
+                .collect(Collectors.toList());
+
+        List<Integer> counts = votingList.stream()
+                .map(VotingResponse::getNumOfTotalParticipants)
+                .collect(Collectors.toList());
+
+        // Then
+        assertThat(titles).contains("무슨 요일날 갈까요?", "어디 여행 갈래");
+        assertThat(counts).containsExactly(0, 0);
+    }
+
+    @Test
+    @DisplayName("투표의 상세 정보를 조회한다")
+    void getVoting() {
+        // Given
+        Long schedule = scheduleService.saveSchedule(TestDataFactory.createScheduleCreation(), MEMBER_ID);
+        VotingCreationRequest votingCreationRequest = new VotingCreationRequest("무슨 요일날 갈까요?", List.of("월", "화", "수", "목"), false);
+
+        Long voting = votingService.saveVoting(schedule, votingCreationRequest, MEMBER_ID);
+
+        // When
+        VotingResponse response = votingService.getVoting(schedule, voting, MEMBER_ID);
+
+        List<String> contents = response.getVotingContentResponses().stream()
+                .map(VotingContentResponse::getContent)
+                .collect(Collectors.toList());
+
+        // Then
+        assertThat(response.getId()).isEqualTo(voting);
+        assertThat(response.getTitle()).isEqualTo("무슨 요일날 갈까요?");
+        assertThat(response.getNumOfTotalParticipants()).isZero();
+        assertThat(response.getMemberSimpleResponse().getId()).isEqualTo(MEMBER_ID);
+        assertThat(contents).containsExactly("월", "화", "수", "목");
+    }
+
+    @Test
+    @DisplayName("투표를 행사 한다")
+    void vote() {
+        // Given
+        Long schedule = scheduleService.saveSchedule(TestDataFactory.createScheduleCreation(), MEMBER_ID);
+        VotingCreationRequest votingCreationRequest = new VotingCreationRequest("무슨 요일날 갈까요?", List.of("월", "화", "수", "목"), false);
+
+        Long voting = votingService.saveVoting(schedule, votingCreationRequest, MEMBER_ID);
+        Voting saved = votingRepository.findById(voting).get();
+
+        List<Long> ids = saved.getVotingContents().stream()
+                .map(VotingContent::getId)
+                .collect(Collectors.toList());
+
+        Map<Long, Boolean> votingMap = Map.of(ids.get(0), true, ids.get(1), false, ids.get(2), false, ids.get(3), false);
+        VotingRequest votingRequest = new VotingRequest(votingMap);
+
+        // When
+        votingService.doVote(schedule, voting, votingRequest, MEMBER_ID);
+
+        List<VotingContent> votingContents = saved.getVotingContents();
+
+        List<Integer> votingCountList = votingContents.stream()
+                .map(VotingContent::getNumOfParticipants)
+                .collect(Collectors.toList());
+
+        // Then
+        votingContents.forEach(votingContent -> {
+            if (votingMap.get(votingContent.getId())) {
+                assertThat(getVotingMemberIds(votingContent)).contains(MEMBER_ID);
+            } else {
+                assertThat(getVotingMemberIds(votingContent)).doesNotContain(MEMBER_ID);
+            }
+        });
+
+        assertThat(votingCountList).containsExactly(1, 0, 0, 0);
+        assertThat(saved.getNumOfTotalParticipants()).isEqualTo(1);
+    }
+
+    private List<Long> getVotingMemberIds(VotingContent votingContent) {
+        return votingContent.getVotingContentMembers()
+                .stream()
+                .map(VotingContentMember::getMemberId)
+                .collect(Collectors.toList());
+    }
+
+    @Test
+    @DisplayName("투표를 삭제한다")
+    void deleteVoting() {
+        // Given
+        Long schedule = scheduleService.saveSchedule(TestDataFactory.createScheduleCreation(), MEMBER_ID);
+        VotingCreationRequest votingCreationRequest = new VotingCreationRequest("무슨 요일날 갈까요?", List.of("월", "화", "수", "목"), false);
+        Long voting = votingService.saveVoting(schedule, votingCreationRequest, MEMBER_ID);
+
+        // When
+        votingService.deleteVoting(schedule, voting, MEMBER_ID);
+        Optional<Voting> actual = votingRepository.findById(voting);
+
+        // Then
+        assertThat(actual).isNotPresent();
+    }
+}


### PR DESCRIPTION
BaseEntity에서 BaseTimeEntity 분리
- 멤버 클래스 같은 경우는 createdBy, LastModifiedBy가 의미가 없으므로 시간과 관련된 BaseTimeEntity를 분리하여 BaseEntity대신에 BaseTimeEntity를 상속받도록 변경

일정 도메인 서비스 클래스 분리
- 기존에 일정 서비스에서 메모, 체크리스트, 투표 등 일정과 관련된 모든 요청을 처리했음
- 이것은 각각의 하위 도메인에 맞게 서비스 클래스를 분리해줌. (기능엔 변화 X)

엔티티 생성 책임을 담당하는 Converter 생성
- 기존에는 Create요청이 들어오면 엔티티를 생성해주는 역할을 서비스 클래스가 담당
- 서비스 클래스의 역할이 너무 많다고 생각하여 엔티티 생성의 책임을 Converter로 위임하였음